### PR TITLE
Add additional jobs functionality to the company command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ List your company FBOs, including fuel, fuel selling status and tied down/hanger
 
 `onair-cli company fbos`
 
+### Company Jobs
+
+List your companie's pending jobs
+
+`onair-cli company jobs`
+
 ### Flight
 
 Display flight data and airport info for a completed flight. In-progress or aborted flights not supported.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ List your company FBOs, including fuel, fuel selling status and tied down/hanger
 
 ### Company Jobs
 
-List your companie's pending jobs
+List your company's pending jobs
 
 `onair-cli company jobs`
 

--- a/src/api/getCompanyJobs.ts
+++ b/src/api/getCompanyJobs.ts
@@ -1,0 +1,23 @@
+import { Company } from '../types/Company';
+import { Job } from '../types/Job';
+import { config } from '../utils/config';
+import onAirRequest, { JobResponse } from './onAirRequest';
+
+
+export const getCompanyJobs = async (companyId: string, apiKey: string, world: string) => {
+  
+  try {
+    const response = await onAirRequest<JobResponse>(
+      `https://${world}${config.apiUrl}company/${companyId}/jobs/pending`,
+      apiKey
+    );
+
+    if (typeof response.data.Content !== 'undefined') {
+      return response.data.Content as Job[];
+    } else {
+      throw new Error(response.data.Error ? response.data.Error : `Company Id "${companyId}"" not found`);
+    };
+  } catch (e) {
+    throw new Error(e.response.status === 400 ? `Company Id "${companyId}"" not found` : e.message);
+  }
+}

--- a/src/api/onAirRequest.ts
+++ b/src/api/onAirRequest.ts
@@ -5,7 +5,7 @@ import { Airport } from "../types/Airport";
 import { Company } from "../types/Company";
 import { Fbo } from "../types/Fbo";
 import { Flight } from "../types/Flight";
-
+import { Job } from "../types/Job";
 import { config } from '../utils/config';
 
 
@@ -33,6 +33,9 @@ export interface FboResponse extends OnAirResponse {
   Content: Fbo[];
 }
 
+export interface JobResponse extends OnAirResponse {
+  Content: Job[];
+}
 /**
  * Generic Get request to OnAir
  * 

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -14,6 +14,9 @@ import { logFlights } from '../loggers/logFlights';
 import { logCompany } from '../loggers/logCompany';
 import { logCompanyFleet } from '../loggers/logCompanyFleet';
 import { logCompanyFbos } from '../loggers/logCompanyFbos';
+import { logCompanyJobs } from '../loggers/logCompanyJobs';
+import { getCompanyJobs } from '../api/getCompanyJobs';
+import { Job } from '../types/Job';
 
 const log = console.log;
 
@@ -22,7 +25,7 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .positional('action', {
       describe: 'Optional info to lookup from your company',
       type: 'string',
-      choices: ['fleet', 'flights', 'fbos'],
+      choices: ['fleet', 'flights', 'fbos', 'jobs'],
     })
     .option('page', {
       'describe': 'Page number (flights only)',
@@ -33,7 +36,8 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .example('$0 company fleet','List your aircraft')
     .example('$0 company flights','List your flights')
     .example('$0 company flights -p=2','List your flights, showing page 2')
-    .example('$0 company fbos', 'List your FBOs');
+    .example('$0 company fbos', 'List your FBOs')
+    .example('$0 company jobs', 'List your pending jobs');
 }
 
 type CompanyCommand = (typeof builder) extends BuilderCallback<CommonConfig, infer R> ? CommandModule<CommonConfig, R> : never;
@@ -87,6 +91,7 @@ export const companyCommand: CompanyCommand = {
             }
             break;
           }
+
           case 'fbos': {
             const companyFbos: Fbo[] = await getCompanyFbos(argv['companyId'], argv['apiKey'], argv['world']);
             
@@ -96,6 +101,19 @@ export const companyCommand: CompanyCommand = {
             } else {
               log('No FBO... no 100LL! ' + chalk.magentaBright('✈'))
             }
+            break;  
+          }
+
+          case 'jobs': {
+            const companyJobs: Job[] = await getCompanyJobs(argv['companyId'], argv['apiKey'], argv['world']);
+
+            if (companyJobs.length) {
+              log(chalk.greenBright.bold('Your Pending Jobs\n'));
+              logCompanyJobs(companyJobs);
+            } else {
+              log('No pending jobs! ' + chalk.magentaBright('✈'))
+            }
+            break;
           }
         }
       }

--- a/src/loggers/logCompanyJobs.ts
+++ b/src/loggers/logCompanyJobs.ts
@@ -9,9 +9,12 @@ export const logCompanyJobs = (companyJobs: Job[]): void => {
   jobTable.push([
     chalk.green('Job Type'),
     chalk.green('Description'),
-    chalk.green('Base Airport'),
     chalk.green('Num Legs'),
+    chalk.green('Base Airport'),
+    chalk.green('Cur Airport'),
+    chalk.green('Dest Airport'),
     chalk.green('Total Distance'),
+    chalk.green('Human Req.'),
     chalk.green('Expires In'),
     chalk.green('Pay'),
     chalk.green('XP')
@@ -40,7 +43,7 @@ export const logCompanyJobs = (companyJobs: Job[]): void => {
     // determine BaseAirport by matching BaseAirportId up within cargo or charter arrays
     let baseAirport: any = undefined;
 
-    if (baseAirport !== undefined && job.Cargos.length > 0) {
+    if (job.Cargos.length > 0) {
       // iterate over Cargos array and find baseAirport
       job.Cargos.find((e) => {
           if (e.DepartureAirport.Id === job.BaseAirportId) {
@@ -53,7 +56,7 @@ export const logCompanyJobs = (companyJobs: Job[]): void => {
       })
     }
 
-    if (baseAirport !== undefined && job.Charters.length > 0) {
+    if (job.Charters.length > 0) {
         job.Charters.find((e) => {
           if (e.DepartureAirport.Id === job.BaseAirportId) {
             baseAirport = e.DepartureAirport
@@ -65,17 +68,69 @@ export const logCompanyJobs = (companyJobs: Job[]): void => {
       })
     }
 
+    // build Job row
+    // Description
+    // Base Airport
+    // Cur Airport
+    // Dest Airport
+    // Num Legs
+    // Total Distance
+    // Human Req
+    
+    // Expires In
+    // Pay
+    // XP
     jobTable.push([
-      job.MissionType.ShortName,
-      job.MissionType.Description,
-      baseAirport.ICAO,
-      `${job.Cargos.length + job.Charters.length} legs`,
-      `${job.TotalDistance} mi`,
-      determineExpiresIn(job.ExpirationDate),
-      `${job.Pay}.00`,
-      `+${job.XP}`,
+      job.MissionType.ShortName, // Job Type
+      null, // Leg Description
+      `${job.Cargos.length + job.Charters.length} legs`, // Num Legs
+      (baseAirport) ? baseAirport.ICAO : null, // Base Airport
+      null, // Cur Airport
+      null, // Dest Airport
+      `${job.TotalDistance} mi`, // Total Distance,
+      null, // Human Req
+      determineExpiresIn(job.ExpirationDate), // Expires In
+      `${job.Pay}.00`, // Pay
+      `+${job.XP}`, // XP
     ])
 
+    if (job.Cargos.length > 0) {
+      job.Cargos.forEach((cargo) => {
+        jobTable.push([
+          null, // Job Type
+          cargo.Description, // Leg Description
+          null, // Num Legs
+          null, // Base Airport
+          (cargo.CurrentAirport) ? cargo.CurrentAirport.ICAO : null, // Cur Airport
+          (cargo.DestinationAirport) ? cargo.DestinationAirport.ICAO : null, // Dest Airport
+          `${cargo.Distance} mi`, // Total Distance
+          (cargo.HumanOnly) ? 'Yes' : 'No', // Human Req
+          null, // Expires In
+          null, // Pay,
+          null, // XP
+
+        ])
+      })
+    }
+
+    if (job.Charters.length > 0) {
+      job.Charters.forEach((charter) => {
+        jobTable.push([
+          null, // Job Type
+          charter.Description, // Leg Description
+          null, // Num Legs
+          null, // Base Airport
+          (charter.CurrentAirport) ? charter.CurrentAirport.ICAO : null, // Cur Airport
+          (charter.DestinationAirport) ? charter.DestinationAirport.ICAO : null, // Dest Airport
+          `${charter.Distance} mi`, // Total Distance
+          (charter.HumanOnly) ? 'Yes' : 'No', // Human Req
+          null, // Expires In
+          null, // Pay,
+          null, // XP
+
+        ])
+      })
+    }
   });
 
   console.log(jobTable.toString());

--- a/src/loggers/logCompanyJobs.ts
+++ b/src/loggers/logCompanyJobs.ts
@@ -1,0 +1,84 @@
+import chalk from "chalk";
+import { Airport } from "../types/Airport";
+import { Job } from "../types/Job";
+import { cliTable } from "../utils/cli-table";
+
+export const logCompanyJobs = (companyJobs: Job[]): void => {
+  const jobTable = cliTable();
+
+  jobTable.push([
+    chalk.green('Job Type'),
+    chalk.green('Description'),
+    chalk.green('Base Airport'),
+    chalk.green('Num Legs'),
+    chalk.green('Total Distance'),
+    chalk.green('Expires In'),
+    chalk.green('Pay'),
+    chalk.green('XP')
+  ]);
+
+  const determineExpiresIn = (dateStr: string) => {
+    const dueDate: any = new Date(dateStr);
+    const today: any = new Date();
+    let output;
+
+    const diffMs = (dueDate - today); // milliseconds between now & dueDate
+    const diffInMinutes = Math.round(((diffMs % 86400000) % 3600000) / 60000); // minutes
+    
+    if (diffInMinutes < 0) {
+      output = chalk.red(`${diffInMinutes} mins`)
+    } else if (diffInMinutes <= 240) {
+      output = chalk.yellow(`${diffInMinutes} mins`)
+    } else if (diffInMinutes > 240) {
+      output = chalk.green(`${diffInMinutes} mins`)
+    }
+
+    return output
+  }
+
+  companyJobs.forEach((job) => {
+    // determine BaseAirport by matching BaseAirportId up within cargo or charter arrays
+    let baseAirport: any = undefined;
+
+    if (baseAirport !== undefined && job.Cargos.length > 0) {
+      // iterate over Cargos array and find baseAirport
+      job.Cargos.find((e) => {
+          if (e.DepartureAirport.Id === job.BaseAirportId) {
+              baseAirport = e.DepartureAirport
+          } else if (e.CurrentAirport.Id === job.BaseAirportId) {
+              baseAirport = e.CurrentAirport
+          }else if (e.DestinationAirport.Id === job.BaseAirportId) {
+              baseAirport = e.DestinationAirport
+          }
+      })
+    }
+
+    if (baseAirport !== undefined && job.Charters.length > 0) {
+        job.Charters.find((e) => {
+          if (e.DepartureAirport.Id === job.BaseAirportId) {
+            baseAirport = e.DepartureAirport
+        } else if (e.CurrentAirport.Id === job.BaseAirportId) {
+            baseAirport = e.CurrentAirport
+        }else if (e.DestinationAirport.Id === job.BaseAirportId) {
+            baseAirport = e.DestinationAirport
+        }
+      })
+    }
+
+    jobTable.push([
+      job.MissionType.ShortName,
+      job.MissionType.Description,
+      baseAirport.ICAO,
+      `${job.Cargos.length + job.Charters.length} legs`,
+      `${job.TotalDistance} mi`,
+      determineExpiresIn(job.ExpirationDate),
+      `${job.Pay}.00`,
+      `+${job.XP}`,
+    ])
+
+  });
+
+  console.log(jobTable.toString());
+
+
+}

--- a/src/loggers/logCompanyJobs.ts
+++ b/src/loggers/logCompanyJobs.ts
@@ -25,7 +25,7 @@ export const logCompanyJobs = (companyJobs: Job[]): void => {
     const diffMs = (dueDate - today); // milliseconds between now & dueDate
     const diffInMinutes = Math.round(((diffMs % 86400000) % 3600000) / 60000); // minutes
     
-    if (diffInMinutes < 0) {
+    if (diffInMinutes <= 0) {
       output = chalk.red(`${diffInMinutes} mins`)
     } else if (diffInMinutes <= 240) {
       output = chalk.yellow(`${diffInMinutes} mins`)

--- a/src/types/Cargo.ts
+++ b/src/types/Cargo.ts
@@ -1,0 +1,33 @@
+import { Airport } from './Airport';
+
+export interface CargoType {
+    Id: string,
+    Name: string,
+    CargoTypeCategory: number,
+    MinLbs: number,
+    MaxLabs: number,
+}
+
+export interface Cargo {
+    Id: string,
+    MissionId: string,
+    CargoTypeId: string,
+    CargoType: CargoType,
+    CurrentAirportId: string,
+    CurrentAirport: Airport,
+    Weight: number,
+    DepartureAirportId: string,
+    DepartureAirport: Airport,
+    DestinationAirportId: string,
+    DestinationAirport: Airport,
+    Distance: number,
+    Heading: number,
+    Description: string,
+    HumanOnly: boolean,
+    CompanyId: string,
+    InRecyclingPool: boolean,
+    RaceValidated: boolean,
+    IsInHangar: boolean,
+    RescueValidated: boolean,
+    RescueLate: boolean,
+}

--- a/src/types/Charter.ts
+++ b/src/types/Charter.ts
@@ -1,0 +1,36 @@
+import { BlobOptions } from "buffer";
+import { Airport } from "./Airport";
+
+export interface CharterType {
+    Id: string,
+    Name: string,
+    CharterTypeCategory: number,
+    MinPAX: number,
+    MaxPAX: number,
+}
+
+export interface Charter {
+    Id: string,
+    MissionId: string,
+    CharterTypeId: string,
+    CharterType: CharterType,
+    CurrentAirportId: string,
+    CurrentAirport: Airport,
+    PassengersNumber: number,
+    DepartureAirportId: String,
+    DepartureAirport: Airport,
+    DestinationAirportId: string,
+    DestinationAirport: Airport,
+    Distance: number,
+    Heading: number
+    Description: string,
+    HumanOnly: boolean,
+    CompanyId: string,
+    CharterPOIMappings: any,
+    InRecyclingPool:  boolean,
+    MinPAXSeatConf: number,
+    BoardedPAXSeat: number,
+    MinAircraftTypeLuxe: number,
+    RescueValidated: boolean,
+    RescueLate: boolean,
+}

--- a/src/types/Company.ts
+++ b/src/types/Company.ts
@@ -1,4 +1,6 @@
-interface CompanySkillPoint {
+import { World } from './World';
+
+export interface CompanySkillPoint {
   Id: string,
   CompanyId: string,
   Company: Record<string, unknown>,
@@ -7,23 +9,13 @@ interface CompanySkillPoint {
   Tag: string,
   Comment: string,
   CreationDate: string
+
 }
 
 export interface Company {
   Id: string,
   WorldId: string,
-  World: {
-    Id: string,
-    Name: string,
-    IsSurvival: boolean,
-    IsHumanOnly: boolean,
-    Fuel100LLBasePrice: number,
-    FuelJetBasePrice: number,
-    JobsBaseBonus: number,
-    JobsMaxBonus: number,
-    ShortName: string,
-    EnableEconomicBalance: boolean
-  },
+  World: World,
   Name: string,
   AirlineCode: string,
   LastConnection: string,

--- a/src/types/Job.ts
+++ b/src/types/Job.ts
@@ -1,0 +1,52 @@
+import { Company, } from './Company';
+import { World } from './World';
+import { Cargo } from './Cargo';
+import { Charter } from './Charter';
+
+export interface MissionType {
+    Id: string,
+    Name: string,
+    ShortName: string,
+    Description: string,
+    BaseReputationImpact: boolean,
+    BasePayFactor: boolean,
+    BasePenalityFactor: boolean,
+}
+
+export interface Job {
+    Id: string,
+    WorldId: string,
+    Cargos: Cargo[],
+    Charters: Charter[],
+    MissionTypeId: string,
+    MissionType: MissionType,
+    MainAirportId: string,
+    BaseAirportId: string,
+    ValuePerLbsPerDistance: number,
+    IsGoodValue: boolean,
+    MaxDistance: number,
+    TotalDistance: number
+    MainAirportHeading: number
+    Description: string,
+    ExpirationDate: string,
+    Pay: number,
+    PayCompanyBonus: number,
+    Penality: number,
+    ReputationImpact: number,
+    CompanyId: string,
+    CreationDate: string,
+    TakenDate: string,
+    TotalCargoTransported: number,
+    TotalPaxTransported: number,
+    Category: number,
+    State: number,
+    XP: number,
+    SkillPoint: number,
+    MinCompanyReput: number,
+    Hash: string,
+    RealPay: number,
+    RealPenality: number,
+    CanAccess: boolean,
+    IsLastMinute: boolean,
+    IsFavorited: boolean,
+}

--- a/src/types/World.ts
+++ b/src/types/World.ts
@@ -1,0 +1,12 @@
+export interface World {
+  Id: string,
+  Name: string,
+  IsSurvival: boolean,
+  IsHumanOnly: boolean,
+  Fuel100LLBasePrice: number,
+  FuelJetBasePrice: number,
+  JobsBaseBonus: number,
+  JobsMaxBonus: number,
+  ShortName: string,
+  EnableEconomicBalance: boolean
+}


### PR DESCRIPTION
Hi there, 
hope this is welcome but, I've taken the liberty of adding an additional `jobs` action under the company command that will list the current pending jobs for the provided company. To use it, simply run `onair-cli company jobs`.

The Expires In timing will be the following colors depending...

- red - < 0
- yellow - <= 240 min (4 hours) 
- green - > 240 min (4 hours)

Also, I was thinking of adding in nested rows after each Job that includes each leg's pertinent details, departure, arrival, pass class/cargo type info...

![image](https://user-images.githubusercontent.com/2991640/150208663-0a25db47-b45c-4f1e-b040-540066937cb3.png)
