### PR TITLE
Show work order details

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ For ease of use save your OnAir credentials.
 
 Your OnAir API key and Company ID are found in the bottom left of the settings page in the OnAir client. The world name is 'cumulus', 'stratus', or 'thunder'. Use 'stratus' for Clear Sky server.
 
+If you are a member of a Virtual Airline (VA), you can also add your VA ID. This can be found in the Manage VA options screen.
+
+`onair-cli set-creds --apiKey=[API_KEY] --world=[WORLD] --companyId=[COMPANY_ID] --vaId=[VIRTUAL_AIRLINE_ID]`
+
 ## Commands
 
 ### Aircraft

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ Display your company's cashflow, including current cash, last report amount and 
 
 `onair-cli company cash-flow`
 
+Optionally show only payment entries, filtered by payment text such as Cargo or PAX.
+
+`onair-cli company cashflow --payment=Cargo`
+
+`onair-cli company cashflow --payment=PAX`
+
 ### Company Work Orders
 
 List your company's work orders.

--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ Optionally show the work order ID.
 
 `onair-cli company work-orders --work-order-id`
 
+Display detailed information for one work order using the ID shown by `--work-order-id`.
+
+`onair-cli company work-orders --work-order-detail=WORK_ORDER_ID`
+
 ### Company Trading Goods
 
 List your company's trading goods.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ Optionally filter FBO jobs by destination airport ICAO.
 
 `onair-cli company fbos --fbojobs --airport-icao=KILM --destination-icao=KERI`
 
+List available destination ICAOs for FBO jobs at an airport.
+
+`onair-cli company fbos --fbojobs --airport-icao=KILM --list-destinations`
+
 ### Company Jobs
 
 List your company's pending jobs

--- a/README.md
+++ b/README.md
@@ -56,6 +56,38 @@ Get summary information on your company. **Note:** You must specify or have prev
 
 `onair-cli company`
 
+### Company Notifications
+
+Display your company's notifications.
+
+`onair-cli company notifications`
+
+This supports pagination showing 20 notifications per page by default.
+
+`onair-cli company notifications --page=2`
+
+Optionally choose how many notifications to display.
+
+`onair-cli company notifications --limit=50`
+
+Optionally fetch multiple pages when you need more than one request.
+
+`onair-cli company notifications --limit=50 --pages=3`
+
+Optionally fetch notifications from now back to a start date.
+
+`onair-cli company notifications --start-date=2026-05-31`
+
+`onair-cli company notifications --start-date=31/05/2026`
+
+Use `--pages` with `--start-date` to cap how many API pages are fetched.
+
+`onair-cli company notifications --start-date=2026-05-31 --limit=50 --pages=5`
+
+Optionally add an end date to fetch a date range.
+
+`onair-cli company notifications --start-date=2026-05-01 --end-date=2026-05-31`
+
 ### Company Fleet
 
 List details of your company's fleet of aircraft.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ List your company's pending jobs
 
 `onair-cli company jobs`
 
+### Company Cashflow
+
+Display your company's cashflow, including current cash, last report amount and cashflow entries.
+
+`onair-cli company cashflow`
+
+`onair-cli company cash-flow`
+
 ### Company Work Orders
 
 List your company's work orders.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,22 @@ Optionally show the work order ID.
 
 `onair-cli company work-orders --work-order-id`
 
+### Company Trading Goods
+
+List your company's trading goods.
+
+`onair-cli company trading-goods`
+
+`onair-cli company trading_goods`
+
+Optionally filter by merchandise type name.
+
+`onair-cli company trading_goods --merchandiseType=Water`
+
+Optionally filter by airport ICAO.
+
+`onair-cli company trading_goods --trading-airport-icao=KJFK`
+
 ### Flight
 
 Display flight data and airport info for a completed flight. In-progress or aborted flights are not supported.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ Optionally filter FBOs by airport ICAO.
 
 `onair-cli company fbos --fbojobs --airport-icao=KILM`
 
+Optionally list only FBOs with less than 50% fuel available. Add `--100LL` or `--Jet` to check a specific fuel type.
+
+`onair-cli company fbos --need-fuel`
+
+`onair-cli company fbos --need-fuel --100LL`
+
+`onair-cli company fbos --need-fuel --Jet`
+
 Optionally filter FBO jobs by destination airport ICAO.
 
 `onair-cli company fbos --fbojobs --airport-icao=KILM --destination-icao=KERI`

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Optionally filter by aircraft ICAO.
 
 `onair-cli company work-orders --aircraft-icao=C172`
 
+Optionally filter by the aircraft's human-readable identifier. Matching is case-insensitive.
+
+`onair-cli company work-orders --aircraft-ident=N123AB`
+
 Optionally show assigned crew with readable names.
 
 `onair-cli company work-orders --show-crew`

--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ Optionally filter by the aircraft's human-readable identifier. Matching is case-
 
 `onair-cli company work-orders --aircraft-ident=N123AB`
 
+Optionally filter by status. Available values are `inactive`, `pending`, `in-progress`, `finished`, `failed`, and `waiting`.
+
+`onair-cli company work-orders --work-order-status=pending`
+
+Status filtering can be combined with the aircraft filters.
+
+`onair-cli company work-orders --aircraft-ident=N123AB --work-order-status=in-progress`
+
 Optionally show assigned crew with readable names.
 
 `onair-cli company work-orders --show-crew`

--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ Optionally filter FBO jobs by destination airport ICAO.
 
 `onair-cli company fbos --fbojobs --airport-icao=KILM --destination-icao=KERI`
 
+List only pending, untaken FBO jobs. Filter by a leg's departure airport, arrival airport, or both.
+
+`onair-cli company fbos --fbojobs --pending-only`
+
+`onair-cli company fbos --fbojobs --pending-only --departure-icao=KILM --arrival-icao=KERI`
+
+`--pending`, `--departure`, and `--arrival` are shorter aliases. The existing `--destination-icao` option remains available as an arrival filter.
+
 List available destination ICAOs for FBO jobs at an airport.
 
 `onair-cli company fbos --fbojobs --airport-icao=KILM --list-destinations`

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ List details of your company's fleet of aircraft.
 
 `onair-cli company fleet`
 
+Filter by aircraft type or airport, and optionally sort by aircraft type.
+
+`onair-cli company fleet --aircraft-type=airbus`
+
+`onair-cli company fleet --airport-icao=KJFK`
+
+`onair-cli company fleet --aircraft-type=airbus --airport-icao=KJFK --sort=aircraft-type`
+
 ### Company Flights
 
 List your company's aircraft flights.
@@ -83,6 +91,24 @@ List your company FBOs, including fuel, fuel selling status and tied down/hanger
 List your company's pending jobs
 
 `onair-cli company jobs`
+
+### Company Work Orders
+
+List your company's work orders.
+
+`onair-cli company work-orders`
+
+Optionally filter by aircraft ICAO.
+
+`onair-cli company work-orders --aircraft-icao=C172`
+
+Optionally show assigned crew with readable names.
+
+`onair-cli company work-orders --show-crew`
+
+Optionally show the work order ID.
+
+`onair-cli company work-orders --work-order-id`
 
 ### Flight
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Optionally show only payment entries, filtered by payment text such as Cargo or 
 
 `onair-cli company cashflow --payment=PAX`
 
+Optionally show readable account names where available.
+
+`onair-cli company cashflow --readable-account-ids`
+
+`onair-cli company cashflow --payment=Cargo --readable-account-ids`
+
 ### Company Work Orders
 
 List your company's work orders.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ List your company FBOs, including fuel, fuel selling status and tied down/hanger
 
 `onair-cli company fbos`
 
+Display FBO jobs grouped under your company FBOs.
+
+`onair-cli company fbos --fbojobs`
+
+Optionally filter FBOs by airport ICAO.
+
+`onair-cli company fbos --fbojobs --airport-icao=KILM`
+
+Optionally filter FBO jobs by destination airport ICAO.
+
+`onair-cli company fbos --fbojobs --airport-icao=KILM --destination-icao=KERI`
+
 ### Company Jobs
 
 List your company's pending jobs

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ Optionally filter by airport ICAO.
 
 `onair-cli company trading_goods --trading-airport-icao=KJFK`
 
+Optionally hide raw IDs or swap them to readable values.
+
+`onair-cli company trading_goods --hide-ids`
+
+`onair-cli company trading_goods --readable-ids`
+
 ### Flight
 
 Display flight data and airport info for a completed flight. In-progress or aborted flights are not supported.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Optionally hide raw IDs or swap them to readable values.
 
 `onair-cli company trading_goods --readable-ids`
 
+Optionally show a one-line summary per trading good.
+
+`onair-cli company trading_goods --summary`
+
 ### Flight
 
 Display flight data and airport info for a completed flight. In-progress or aborted flights are not supported.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onair-cli",
-  "version": "1.5.0-alpha.0",
+  "version": "1.5.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "onair-cli",
-      "version": "1.5.0-alpha.0",
+      "version": "1.5.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.22.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1912,15 +1912,9 @@
       }
     },
     "node_modules/onair-api": {
-<<<<<<< HEAD
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/onair-api/-/onair-api-1.0.13.tgz",
       "integrity": "sha512-BOeuamfbtg4q2/mBSfzqAu2XnRdziW538O2b+IyLOIfLnz5kFJI2Ixn+96w9LyIeKWj6GzX9qtsZvGwNfMm8GA==",
-=======
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/onair-api/-/onair-api-1.0.7.tgz",
-      "integrity": "sha512-k+/36SuCI5kLo9DJDMLYQFD8dD46L73zoDDYZPBpE4BCIer8QupulKABoL7u3WzaEO/7gn3AnaXOBRyCmXdbaw==",
->>>>>>> Add company income statement summary command
       "dependencies": {
         "axios": "^0.24.0",
         "dotenv": "^14.1.0"
@@ -3962,15 +3956,9 @@
       }
     },
     "onair-api": {
-<<<<<<< HEAD
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/onair-api/-/onair-api-1.0.13.tgz",
       "integrity": "sha512-BOeuamfbtg4q2/mBSfzqAu2XnRdziW538O2b+IyLOIfLnz5kFJI2Ixn+96w9LyIeKWj6GzX9qtsZvGwNfMm8GA==",
-=======
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/onair-api/-/onair-api-1.0.7.tgz",
-      "integrity": "sha512-k+/36SuCI5kLo9DJDMLYQFD8dD46L73zoDDYZPBpE4BCIer8QupulKABoL7u3WzaEO/7gn3AnaXOBRyCmXdbaw==",
->>>>>>> Add company income statement summary command
       "requires": {
         "axios": "^0.24.0",
         "dotenv": "^14.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onair-cli",
-  "version": "1.4.1",
+  "version": "1.5.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "onair-cli",
-      "version": "1.4.1",
+      "version": "1.5.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.22.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1912,9 +1912,15 @@
       }
     },
     "node_modules/onair-api": {
+<<<<<<< HEAD
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/onair-api/-/onair-api-1.0.13.tgz",
       "integrity": "sha512-BOeuamfbtg4q2/mBSfzqAu2XnRdziW538O2b+IyLOIfLnz5kFJI2Ixn+96w9LyIeKWj6GzX9qtsZvGwNfMm8GA==",
+=======
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/onair-api/-/onair-api-1.0.7.tgz",
+      "integrity": "sha512-k+/36SuCI5kLo9DJDMLYQFD8dD46L73zoDDYZPBpE4BCIer8QupulKABoL7u3WzaEO/7gn3AnaXOBRyCmXdbaw==",
+>>>>>>> Add company income statement summary command
       "dependencies": {
         "axios": "^0.24.0",
         "dotenv": "^14.1.0"
@@ -3956,9 +3962,15 @@
       }
     },
     "onair-api": {
+<<<<<<< HEAD
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/onair-api/-/onair-api-1.0.13.tgz",
       "integrity": "sha512-BOeuamfbtg4q2/mBSfzqAu2XnRdziW538O2b+IyLOIfLnz5kFJI2Ixn+96w9LyIeKWj6GzX9qtsZvGwNfMm8GA==",
+=======
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/onair-api/-/onair-api-1.0.7.tgz",
+      "integrity": "sha512-k+/36SuCI5kLo9DJDMLYQFD8dD46L73zoDDYZPBpE4BCIer8QupulKABoL7u3WzaEO/7gn3AnaXOBRyCmXdbaw==",
+>>>>>>> Add company income statement summary command
       "requires": {
         "axios": "^0.24.0",
         "dotenv": "^14.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onair-cli",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "onair-cli",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.22.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onair-cli",
-  "version": "1.5.0-alpha.1",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "onair-cli",
-      "version": "1.5.0-alpha.1",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.22.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onair-cli",
   "description": "A CLI to display information from OnAir Airline Manager",
-  "version": "1.5.0-alpha.0",
+  "version": "1.5.0-alpha.1",
   "main": "bin/index.js",
   "author": {
     "name": "Will Kelly",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,7 @@
 {
   "name": "onair-cli",
   "description": "A CLI to display information from OnAir Airline Manager",
-<<<<<<< HEAD
-  "version": "1.4.1",
-=======
   "version": "1.5.0-alpha.0",
->>>>>>> 1.5.0-alpha.0
   "main": "bin/index.js",
   "author": {
     "name": "Will Kelly",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "onair-cli",
   "description": "A CLI to display information from OnAir Airline Manager",
+<<<<<<< HEAD
   "version": "1.4.1",
+=======
+  "version": "1.5.0-alpha.0",
+>>>>>>> 1.5.0-alpha.0
   "main": "bin/index.js",
   "author": {
     "name": "Will Kelly",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "prepublishOnly": "npm run build",
     "version": "git add -A",
     "postversion": "git push && git push --tags",
+    "test": "npm run build && node test/logCompanyWorkOrders.test.js",
     "lint": "eslint src --ext .ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prepublishOnly": "npm run build",
     "version": "git add -A",
     "postversion": "git push && git push --tags",
-    "test": "npm run build && node test/logCompanyWorkOrders.test.js",
+    "test": "npm run build && node test/logCompanyWorkOrders.test.js && node test/fboJobFilters.test.js",
     "lint": "eslint src --ext .ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onair-cli",
   "description": "A CLI to display information from OnAir Airline Manager",
-  "version": "1.5.0-alpha.1",
+  "version": "1.6.0",
   "main": "bin/index.js",
   "author": {
     "name": "Will Kelly",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onair-cli",
   "description": "A CLI to display information from OnAir Airline Manager",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "bin/index.js",
   "author": {
     "name": "Will Kelly",

--- a/src/api/getCompanyFbos.ts
+++ b/src/api/getCompanyFbos.ts
@@ -1,0 +1,11 @@
+import { Fbo } from 'onair-api';
+
+import { getOnAirContent } from './onAirRequest';
+
+export const getCompanyFbos = async (companyId: string, apiKey: string): Promise<Fbo[]> => {
+  return getOnAirContent<Fbo>(
+    `https://server1.onair.company/api/v1/company/${companyId}/fbos`,
+    apiKey,
+    `Company Id "${companyId}" not found`
+  );
+};

--- a/src/api/getCompanyJobs.ts
+++ b/src/api/getCompanyJobs.ts
@@ -1,0 +1,15 @@
+import { Job } from 'onair-api';
+
+import { getOnAirContent } from './onAirRequest';
+
+export const getCompanyJobs = async (
+  companyId: string,
+  apiKey: string,
+  completed = false
+): Promise<Job[]> => {
+  return getOnAirContent<Job>(
+    `https://server1.onair.company/api/v1/company/${companyId}/jobs/${completed ? 'completed' : 'pending'}`,
+    apiKey,
+    `Company Id "${companyId}" not found`
+  );
+};

--- a/src/api/getCompanyNotifications.ts
+++ b/src/api/getCompanyNotifications.ts
@@ -1,0 +1,51 @@
+import axios from 'axios';
+
+export interface CompanyNotification {
+  Id: string;
+  AircraftId?: string;
+  PeopleId?: string;
+  CompanyId: string;
+  IsRead: boolean;
+  IsNotification: boolean;
+  ZuluEventTime: string;
+  Category: number;
+  Action: number;
+  Description: string;
+  Amount: number;
+}
+
+interface CompanyNotificationsResponse {
+  Error: string;
+  Content?: CompanyNotification[] | CompanyNotification;
+}
+
+export const getCompanyNotifications = async (
+  companyId: string,
+  apiKey: string,
+  startIndex = 0,
+  limit = 20
+): Promise<CompanyNotification[]> => {
+  try {
+    const response = await axios.get<CompanyNotificationsResponse>(
+      `https://server1.onair.company/api/v1/company/${companyId}/notifications`,
+      {
+        headers: {
+          'oa-apikey': apiKey,
+          'Accept': 'application/json',
+        },
+        params: {
+          startIndex,
+          limit,
+        },
+      }
+    );
+
+    if (typeof response.data.Content === 'undefined') {
+      throw new Error(response.data.Error ? response.data.Error : `Company Id "${companyId}" not found`);
+    }
+
+    return Array.isArray(response.data.Content) ? response.data.Content : [response.data.Content];
+  } catch (e) {
+    throw new Error(e.response?.status === 400 ? `Company Id "${companyId}" not found` : e.message);
+  }
+};

--- a/src/api/getCompanyTradingGoods.ts
+++ b/src/api/getCompanyTradingGoods.ts
@@ -1,0 +1,32 @@
+import axios from 'axios';
+
+export interface CompanyTradingGood {
+  [key: string]: unknown;
+}
+
+interface CompanyTradingGoodsResponse {
+  Error: string;
+  Content?: CompanyTradingGood[] | CompanyTradingGood;
+}
+
+export const getCompanyTradingGoods = async (companyId: string, apiKey: string): Promise<CompanyTradingGood[]> => {
+  try {
+    const response = await axios.get<CompanyTradingGoodsResponse>(
+      `https://server1.onair.company/api/v1/company/${companyId}/trading_goods`,
+      {
+        headers: {
+          'oa-apikey': apiKey,
+          'Accept': 'application/json',
+        },
+      }
+    );
+
+    if (typeof response.data.Content === 'undefined') {
+      throw new Error(response.data.Error ? response.data.Error : `Company Id "${companyId}" not found`);
+    }
+
+    return Array.isArray(response.data.Content) ? response.data.Content : [response.data.Content];
+  } catch (e) {
+    throw new Error(e.response?.status === 400 ? `Company Id "${companyId}" not found` : e.message);
+  }
+};

--- a/src/api/getCompanyWorkOrders.ts
+++ b/src/api/getCompanyWorkOrders.ts
@@ -1,0 +1,45 @@
+import axios, { AxiosRequestConfig } from 'axios';
+
+import { CompanyWorkOrder } from '../types/CompanyWorkOrder';
+
+interface CompanyWorkOrderResponse {
+  Error?: string;
+  Content?: CompanyWorkOrder[];
+}
+
+const endpointCandidates = [
+  'workorders',
+  'work-orders',
+  'workOrders',
+];
+
+export const getCompanyWorkOrders = async (companyId: string, apiKey: string) => {
+  const axiosConfig: AxiosRequestConfig = {
+    headers: {
+      'oa-apikey': apiKey,
+      'Accept': 'application/json',
+      'User-Agent': `onair-cli v${process.env.npm_package_version || 'dev'}`
+    },
+  };
+
+  let lastError: Error | undefined;
+
+  for (const endpoint of endpointCandidates) {
+    try {
+      const response = await axios.get<CompanyWorkOrderResponse>(
+        `https://server1.onair.company/api/v1/company/${companyId}/${endpoint}`,
+        axiosConfig
+      );
+
+      if (typeof response.data.Content !== 'undefined') {
+        return response.data.Content;
+      }
+
+      throw new Error(response.data.Error || 'Work orders were not returned by the API');
+    } catch (e) {
+      lastError = e as Error;
+    }
+  }
+
+  throw lastError || new Error(`Company Id "${companyId}" not found`);
+};

--- a/src/api/getFboJobs.ts
+++ b/src/api/getFboJobs.ts
@@ -1,0 +1,11 @@
+import { Job } from 'onair-api';
+
+import { getOnAirContent } from './onAirRequest';
+
+export const getFboJobs = async (fboId: string, apiKey: string): Promise<Job[]> => {
+  return getOnAirContent<Job>(
+    `https://server1.onair.company/api/v1/fbo/${fboId}/jobs`,
+    apiKey,
+    `FBO Id "${fboId}" not found`
+  );
+};

--- a/src/api/onAirRequest.ts
+++ b/src/api/onAirRequest.ts
@@ -1,0 +1,42 @@
+import axios, { AxiosRequestConfig } from 'axios';
+import https from 'https';
+
+const onAirHttpsAgent = new https.Agent({
+  rejectUnauthorized: false,
+});
+
+interface OnAirResponse<T> {
+  Error?: string;
+  Content?: T | T[];
+}
+
+export const getOnAirContent = async <T>(
+  url: string,
+  apiKey: string,
+  notFoundMessage: string,
+  requestData?: Record<string, unknown>
+): Promise<T[]> => {
+  try {
+    const axiosConfig: AxiosRequestConfig = {
+      headers: {
+        'oa-apikey': apiKey,
+        'Accept': 'application/json',
+      },
+      httpsAgent: onAirHttpsAgent,
+    };
+
+    if (typeof requestData !== 'undefined') {
+      axiosConfig.params = requestData;
+    }
+
+    const response = await axios.get<OnAirResponse<T>>(url, axiosConfig);
+
+    if (typeof response.data.Content === 'undefined') {
+      throw new Error(response.data.Error ? response.data.Error : notFoundMessage);
+    }
+
+    return Array.isArray(response.data.Content) ? response.data.Content : [response.data.Content];
+  } catch (e) {
+    throw new Error(e.response?.status === 400 ? notFoundMessage : e.message);
+  }
+};

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -2,7 +2,9 @@ import yargs, { BuilderCallback, CommandModule } from 'yargs';
 import chalk from 'chalk';
 import OnAirApi, { OnAirApiConfig, Company, Aircraft, Flight, Fbo, Job, IncomeStatement } from 'onair-api';
 
+import { CompanyTradingGood, getCompanyTradingGoods } from '../api/getCompanyTradingGoods';
 import { getCompanyWorkOrders } from '../api/getCompanyWorkOrders';
+import { logCompanyTradingGoods } from '../loggers/logCompanyTradingGoods';
 import { logCompanyWorkOrders, getWorkOrderAircraftIcao } from '../loggers/logCompanyWorkOrders';
 import { CompanyWorkOrder } from '../types/CompanyWorkOrder';
 import { CommonConfig } from '../utils/commonTypes';
@@ -15,12 +17,73 @@ import { logCompanyIncome } from '../loggers/logCompanyIncome';
 
 const log = console.log;
 
+const getNestedStringValue = (value: unknown, path: string[]): string | undefined => {
+  let current: unknown = value;
+
+  for (const segment of path) {
+    if (typeof current !== 'object' || current === null || !(segment in current)) {
+      return undefined;
+    }
+
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return typeof current === 'string' ? current : undefined;
+};
+
+const filterTradingGoods = (tradingGoods: CompanyTradingGood[], merchandiseTypeName?: string): CompanyTradingGood[] => {
+  if (!merchandiseTypeName) {
+    return tradingGoods;
+  }
+
+  const filterValue = merchandiseTypeName.toLocaleLowerCase();
+
+  return tradingGoods.filter((good) => {
+    const name = getNestedStringValue(good, ['MerchandiseType', 'Name']);
+    return typeof name === 'string' && name.toLocaleLowerCase().includes(filterValue);
+  });
+};
+
+const filterTradingGoodsByAirportIcao = (tradingGoods: CompanyTradingGood[], airportIcao?: string): CompanyTradingGood[] => {
+  if (!airportIcao) {
+    return tradingGoods;
+  }
+
+  const filterValue = airportIcao.toLocaleUpperCase();
+
+  return tradingGoods.filter((good) => {
+    const icao = getNestedStringValue(good, ['CurrentAirport', 'ICAO']);
+    return typeof icao === 'string' && icao.toLocaleUpperCase() === filterValue;
+  });
+};
+
+const sortTradingGoodsByAirportIcao = <T extends Record<string, unknown>>(tradingGoods: T[]): T[] => {
+  return [...tradingGoods].sort((left, right) => {
+    const leftIcao = getNestedStringValue(left, ['CurrentAirport', 'ICAO']) || '';
+    const rightIcao = getNestedStringValue(right, ['CurrentAirport', 'ICAO']) || '';
+
+    if (!leftIcao && !rightIcao) {
+      return 0;
+    }
+
+    if (!leftIcao) {
+      return 1;
+    }
+
+    if (!rightIcao) {
+      return -1;
+    }
+
+    return leftIcao.localeCompare(rightIcao);
+  });
+};
+
 const builder = (yargs: yargs.Argv<CommonConfig>) => {
   return yargs
     .positional('action', {
       describe: 'Optional info to lookup from your company',
       type: 'string',
-      choices: ['fleet', 'flights', 'fbos', 'jobs', 'income', 'work-orders'],
+      choices: ['fleet', 'flights', 'fbos', 'jobs', 'income', 'work-orders', 'trading-goods', 'trading_goods'],
     })
     .option('page', {
       'describe': 'Page number (flights only)',
@@ -58,6 +121,15 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
       'type': 'boolean',
       'default': false,
     })
+    .option('merchandiseType', {
+      describe: 'Filter trading goods by MerchandiseType.Name',
+      type: 'string',
+      alias: 'm',
+    })
+    .option('trading-airport-icao', {
+      describe: 'Filter trading goods by CurrentAirport.ICAO',
+      type: 'string',
+    })
     .example('$0 company','Get summary information for your company')
     .example('$0 company fleet','List your aircraft')
     .example('$0 company fleet --aircraft-type=airbus', 'List only matching aircraft types')
@@ -72,7 +144,10 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .example('$0 company work-orders', 'List your company work orders')
     .example('$0 company work-orders --aircraft-icao=C172', 'List work orders for one aircraft ICAO')
     .example('$0 company work-orders --show-crew', 'List work orders with assigned crew names')
-    .example('$0 company work-orders --work-order-id', 'List work orders including the work order ID');
+    .example('$0 company work-orders --work-order-id', 'List work orders including the work order ID')
+    .example('$0 company trading-goods', 'List your trading goods')
+    .example('$0 company trading_goods --merchandiseType=Water', 'Filter trading goods by merchandise type name')
+    .example('$0 company trading_goods --trading-airport-icao=KJFK', 'Filter trading goods by airport ICAO');
 }
 
 type CompanyCommand = (typeof builder) extends BuilderCallback<CommonConfig, infer R> ? CommandModule<CommonConfig, R> : never;
@@ -215,6 +290,31 @@ export const companyCommand: CompanyCommand = {
               log(workOrders.length
                 ? 'No work orders matched your aircraft ICAO filter.'
                 : 'No work orders found.');
+            }
+            break;
+          }
+
+          case 'trading-goods':
+          case 'trading_goods': {
+            const companyTradingGoods = await getCompanyTradingGoods(argv['companyId'], argv['apiKey']);
+            const filteredTradingGoodsByMerchandiseType = filterTradingGoods(companyTradingGoods, argv['merchandiseType']);
+            const filteredTradingGoods = filterTradingGoodsByAirportIcao(
+              filteredTradingGoodsByMerchandiseType,
+              typeof argv['trading-airport-icao'] === 'string'
+                ? argv['trading-airport-icao'].trim()
+                : undefined
+            );
+            const sortedTradingGoods = sortTradingGoodsByAirportIcao(filteredTradingGoods);
+
+            if (sortedTradingGoods.length) {
+              log(chalk.greenBright.bold('Your Trading Goods\n'));
+              logCompanyTradingGoods(sortedTradingGoods);
+            } else {
+              log(
+                argv['merchandiseType'] || argv['trading-airport-icao']
+                  ? 'No trading goods found for the supplied filters.'
+                  : 'No trading goods found.'
+              );
             }
             break;
           }

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -61,9 +61,11 @@ const sortTradingGoodsByAirportIcao = <T extends Record<string, unknown>>(tradin
   return [...tradingGoods].sort((left, right) => {
     const leftIcao = getNestedStringValue(left, ['CurrentAirport', 'ICAO']) || '';
     const rightIcao = getNestedStringValue(right, ['CurrentAirport', 'ICAO']) || '';
+    const leftMerchandiseType = getNestedStringValue(left, ['MerchandiseType', 'Name']) || '';
+    const rightMerchandiseType = getNestedStringValue(right, ['MerchandiseType', 'Name']) || '';
 
     if (!leftIcao && !rightIcao) {
-      return 0;
+      return leftMerchandiseType.localeCompare(rightMerchandiseType);
     }
 
     if (!leftIcao) {
@@ -74,7 +76,13 @@ const sortTradingGoodsByAirportIcao = <T extends Record<string, unknown>>(tradin
       return -1;
     }
 
-    return leftIcao.localeCompare(rightIcao);
+    const airportSort = leftIcao.localeCompare(rightIcao);
+
+    if (airportSort !== 0) {
+      return airportSort;
+    }
+
+    return leftMerchandiseType.localeCompare(rightMerchandiseType);
   });
 };
 
@@ -130,6 +138,16 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
       describe: 'Filter trading goods by CurrentAirport.ICAO',
       type: 'string',
     })
+    .option('hide-ids', {
+      describe: 'Hide raw ID columns for trading goods',
+      type: 'boolean',
+      default: false,
+    })
+    .option('readable-ids', {
+      describe: 'Swap trading goods ID columns to readable values where possible',
+      type: 'boolean',
+      default: false,
+    })
     .example('$0 company','Get summary information for your company')
     .example('$0 company fleet','List your aircraft')
     .example('$0 company fleet --aircraft-type=airbus', 'List only matching aircraft types')
@@ -147,7 +165,9 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .example('$0 company work-orders --work-order-id', 'List work orders including the work order ID')
     .example('$0 company trading-goods', 'List your trading goods')
     .example('$0 company trading_goods --merchandiseType=Water', 'Filter trading goods by merchandise type name')
-    .example('$0 company trading_goods --trading-airport-icao=KJFK', 'Filter trading goods by airport ICAO');
+    .example('$0 company trading_goods --trading-airport-icao=KJFK', 'Filter trading goods by airport ICAO')
+    .example('$0 company trading_goods --hide-ids', 'Hide raw ID columns for trading goods')
+    .example('$0 company trading_goods --readable-ids', 'Show human readable values instead of raw trading goods IDs');
 }
 
 type CompanyCommand = (typeof builder) extends BuilderCallback<CommonConfig, infer R> ? CommandModule<CommonConfig, R> : never;
@@ -308,7 +328,7 @@ export const companyCommand: CompanyCommand = {
 
             if (sortedTradingGoods.length) {
               log(chalk.greenBright.bold('Your Trading Goods\n'));
-              logCompanyTradingGoods(sortedTradingGoods);
+              logCompanyTradingGoods(sortedTradingGoods, argv['hide-ids'], argv['readable-ids']);
             } else {
               log(
                 argv['merchandiseType'] || argv['trading-airport-icao']

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -19,6 +19,7 @@ import {
 } from '../loggers/logCompanyWorkOrders';
 import { CompanyWorkOrder } from '../types/CompanyWorkOrder';
 import { CommonConfig } from '../utils/commonTypes';
+import { matchesFboJobFilters } from '../utils/fboJobFilters';
 import { logFlights } from '../loggers/logFlights';
 import { logCompany } from '../loggers/logCompany';
 import { logCompanyFleet } from '../loggers/logCompanyFleet';
@@ -212,12 +213,6 @@ const parseNotificationFilterDate = (dateValue: string | undefined, optionName: 
   return parsedDate;
 };
 
-const jobHasDestinationIcao = (job: Job, destinationIcao: string): boolean => {
-  return [...job.Cargos, ...job.Charters].some((leg) => {
-    return leg.DestinationAirport?.ICAO?.toLocaleUpperCase() === destinationIcao;
-  });
-};
-
 const isFuelBelowHalf = (quantity: number, capacity: number): boolean => {
   return capacity > 0 && quantity < capacity / 2;
 };
@@ -354,6 +349,22 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
       type: 'string',
       alias: 'destination',
     })
+    .option('departure-icao', {
+      describe: 'Filter FBO jobs by leg departure airport ICAO (fbos --fbojobs only)',
+      type: 'string',
+      alias: 'departure',
+    })
+    .option('arrival-icao', {
+      describe: 'Filter FBO jobs by leg arrival airport ICAO (fbos --fbojobs only)',
+      type: 'string',
+      alias: 'arrival',
+    })
+    .option('pending-only', {
+      describe: 'Show only pending, untaken FBO jobs (fbos --fbojobs only)',
+      type: 'boolean',
+      alias: 'pending',
+      default: false,
+    })
     .option('list-destinations', {
       describe: 'List available destination ICAOs for FBO jobs (fbos --fbojobs only)',
       type: 'boolean',
@@ -389,6 +400,7 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .example('$0 company fbos --fbojobs', 'List your FBOs with jobs grouped under each FBO')
     .example('$0 company fbos --fbojobs --airport-icao=KJFK', 'List FBO jobs for one airport')
     .example('$0 company fbos --fbojobs --airport-icao=KJFK --destination-icao=KORD', 'List FBO jobs for one airport with legs to a destination')
+    .example('$0 company fbos --fbojobs --pending-only --departure-icao=KJFK --arrival-icao=KORD', 'List pending FBO jobs for a route')
     .example('$0 company fbos --fbojobs --airport-icao=KJFK --list-destinations', 'List available FBO job destination ICAOs for one airport')
     .example('$0 company jobs', 'List your pending jobs')
     .example('$0 company income', 'Display your company income statement summary')
@@ -521,14 +533,23 @@ export const companyCommand: CompanyCommand = {
                 const destinationIcaoFilter = typeof argv['destination-icao'] === 'string'
                   ? argv['destination-icao'].trim().toLocaleUpperCase()
                   : undefined;
+                const departureIcaoFilter = typeof argv['departure-icao'] === 'string'
+                  ? argv['departure-icao'].trim().toLocaleUpperCase()
+                  : undefined;
+                const arrivalIcaoFilter = typeof argv['arrival-icao'] === 'string'
+                  ? argv['arrival-icao'].trim().toLocaleUpperCase()
+                  : destinationIcaoFilter;
+                const pendingOnlyFilter = Boolean(argv['pending-only']);
                 const companyFboJobs = await Promise.all(filteredFbos.map(async (fbo) => {
                   const fboJobs = await getFboJobs(fbo.Id, apiKey);
 
                   return {
                     fbo,
-                    jobs: destinationIcaoFilter
-                      ? fboJobs.filter((job) => jobHasDestinationIcao(job, destinationIcaoFilter))
-                      : fboJobs,
+                    jobs: fboJobs.filter((job) => matchesFboJobFilters(job, {
+                      pendingOnly: pendingOnlyFilter,
+                      departureIcao: departureIcaoFilter,
+                      arrivalIcao: arrivalIcaoFilter,
+                    })),
                   };
                 }));
                 if (argv['list-destinations']) {

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -2,6 +2,9 @@ import yargs, { BuilderCallback, CommandModule } from 'yargs';
 import chalk from 'chalk';
 import OnAirApi, { OnAirApiConfig, Company, Aircraft, Flight, Fbo, Job, IncomeStatement, CashFlow, BalanceSheet, Account } from 'onair-api';
 
+import { getCompanyFbos } from '../api/getCompanyFbos';
+import { getCompanyJobs } from '../api/getCompanyJobs';
+import { getFboJobs } from '../api/getFboJobs';
 import { CompanyTradingGood, getCompanyTradingGoods } from '../api/getCompanyTradingGoods';
 import { CompanyNotification, getCompanyNotifications } from '../api/getCompanyNotifications';
 import { getCompanyWorkOrders } from '../api/getCompanyWorkOrders';
@@ -242,6 +245,7 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .option('airport-icao', {
       'describe': 'Filter fleet by current airport ICAO, or FBOs by airport ICAO',
       'type': 'string',
+      'alias': 'airport-iaco',
     })
     .option('sort', {
       'describe': 'Sort fleet results',
@@ -420,7 +424,7 @@ export const companyCommand: CompanyCommand = {
           }
 
           case 'fbos': {
-            const companyFbos: Fbo[] = await api.getCompanyFbos();
+            const companyFbos: Fbo[] = await getCompanyFbos(argv['companyId'], argv['apiKey']);
             const airportIcaoFilter = typeof argv['airport-icao'] === 'string'
               ? argv['airport-icao'].trim().toLocaleUpperCase()
               : undefined;
@@ -432,9 +436,15 @@ export const companyCommand: CompanyCommand = {
             
             if (filteredFbos.length) {
               if (argv['fbojobs']) {
-                const companyJobs: Job[] = await api.getCompanyJobs();
+                const apiKey = argv['apiKey'];
+                const companyFboJobs = await Promise.all(filteredFbos.map(async (fbo) => {
+                  return {
+                    fbo,
+                    jobs: await getFboJobs(fbo.Id, apiKey),
+                  };
+                }));
                 log(chalk.greenBright.bold('Your FBO Jobs\n'));
-                logCompanyFboJobs(filteredFbos, companyJobs);
+                logCompanyFboJobs(companyFboJobs);
               } else {
                 log(chalk.greenBright.bold('Your FBOs\n'));
                 logCompanyFbos(filteredFbos);
@@ -448,7 +458,7 @@ export const companyCommand: CompanyCommand = {
           }
 
           case 'jobs': {
-            const companyJobs: Job[] = await api.getCompanyJobs();
+            const companyJobs: Job[] = await getCompanyJobs(argv['companyId'], argv['apiKey']);
 
             if (companyJobs.length) {
               log(chalk.greenBright.bold('Your Pending Jobs\n'));

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -15,7 +15,7 @@ import { logCompanyFbos } from '../loggers/logCompanyFbos';
 import { logCompanyFboJobs } from '../loggers/logCompanyFboJobs';
 import { logCompanyJobs } from '../loggers/logCompanyJobs';
 import { logCompanyIncome } from '../loggers/logCompanyIncome';
-import { logCompanyCashFlow } from '../loggers/logCompanyCashFlow';
+import { CashFlowPaymentEntry, logCompanyCashFlow, logCompanyCashFlowPayments } from '../loggers/logCompanyCashFlow';
 
 const log = console.log;
 
@@ -86,6 +86,23 @@ const sortTradingGoodsByAirportIcao = <T extends Record<string, unknown>>(tradin
 
     return leftMerchandiseType.localeCompare(rightMerchandiseType);
   });
+};
+
+const isPaymentEntry = (entry: CashFlowPaymentEntry, paymentFilter?: string): boolean => {
+  if (!entry.Description.toLocaleLowerCase().startsWith('payment for ')) {
+    return false;
+  }
+
+  return paymentFilter
+    ? entry.Description.toLocaleLowerCase().includes(paymentFilter.toLocaleLowerCase())
+    : true;
+};
+
+const getAircraftLookup = (aircraft: Aircraft[]): Record<string, string> => {
+  return aircraft.reduce((lookup, fleetAircraft) => {
+    lookup[fleetAircraft.Id] = fleetAircraft.Identifier;
+    return lookup;
+  }, {} as Record<string, string>);
 };
 
 const builder = (yargs: yargs.Argv<CommonConfig>) => {
@@ -161,6 +178,10 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
       type: 'boolean',
       default: false,
     })
+    .option('payment', {
+      describe: 'Show cashflow payment entries, optionally filtered by text such as Cargo or PAX (cashflow only)',
+      type: 'string',
+    })
     .example('$0 company','Get summary information for your company')
     .example('$0 company fleet','List your aircraft')
     .example('$0 company fleet --aircraft-type=airbus', 'List only matching aircraft types')
@@ -176,6 +197,8 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .example('$0 company income', 'Display your company income statement summary')
     .example('$0 company income --days=30', 'Display your statement summary for the last 30 days')
     .example('$0 company cashflow', 'Display your company cashflow')
+    .example('$0 company cashflow --payment=Cargo', 'Display cashflow payment entries matching Cargo')
+    .example('$0 company cashflow --payment=PAX', 'Display cashflow payment entries matching PAX')
     .example('$0 company work-orders', 'List your company work orders')
     .example('$0 company work-orders --aircraft-icao=C172', 'List work orders for one aircraft ICAO')
     .example('$0 company work-orders --show-crew', 'List work orders with assigned crew names')
@@ -326,7 +349,24 @@ export const companyCommand: CompanyCommand = {
           case 'cashflow':
           case 'cash-flow': {
             const cashFlow: CashFlow = await api.getCompanyCashFlow();
-            if (cashFlow.Entries.length) {
+            const paymentFilter = typeof argv['payment'] === 'string' && argv['payment'].trim()
+              ? argv['payment'].trim()
+              : undefined;
+
+            if (typeof argv['payment'] !== 'undefined') {
+              const paymentEntries = (cashFlow.Entries as CashFlowPaymentEntry[])
+                .filter((entry) => isPaymentEntry(entry, paymentFilter));
+
+              if (paymentEntries.length) {
+                const companyFleet: Aircraft[] = await api.getCompanyFleet();
+                log(chalk.greenBright.bold('Your cashflow payments\n'));
+                logCompanyCashFlowPayments(paymentEntries, getAircraftLookup(companyFleet));
+              } else {
+                log(paymentFilter
+                  ? `No cashflow payment entries matched "${paymentFilter}".`
+                  : 'No cashflow payment entries found.');
+              }
+            } else if (cashFlow.Entries.length) {
               log(chalk.greenBright.bold('Your cashflow\n'));
               logCompanyCashFlow(cashFlow);
             } else {

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import OnAirApi, { OnAirApiConfig, Company, Aircraft, Flight, Fbo, Job, IncomeStatement, CashFlow, BalanceSheet, Account } from 'onair-api';
 
 import { CompanyTradingGood, getCompanyTradingGoods } from '../api/getCompanyTradingGoods';
+import { CompanyNotification, getCompanyNotifications } from '../api/getCompanyNotifications';
 import { getCompanyWorkOrders } from '../api/getCompanyWorkOrders';
 import { logCompanyTradingGoods, logCompanyTradingGoodsSummary } from '../loggers/logCompanyTradingGoods';
 import { logCompanyWorkOrders, getWorkOrderAircraftIcao } from '../loggers/logCompanyWorkOrders';
@@ -16,6 +17,7 @@ import { logCompanyFboJobs } from '../loggers/logCompanyFboJobs';
 import { logCompanyJobs } from '../loggers/logCompanyJobs';
 import { logCompanyIncome } from '../loggers/logCompanyIncome';
 import { AccountLookup, CashFlowPaymentEntry, logCompanyCashFlow, logCompanyCashFlowPayments } from '../loggers/logCompanyCashFlow';
+import { logCompanyNotifications } from '../loggers/logCompanyNotifications';
 
 const log = console.log;
 
@@ -167,17 +169,67 @@ const getAccountLookup = (income: IncomeStatement, balanceSheet: BalanceSheet): 
   return lookup;
 };
 
+const parseDateOnly = (startDate: string): Date | undefined => {
+  const isoDate = startDate.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (isoDate) {
+    return new Date(Number(isoDate[1]), Number(isoDate[2]) - 1, Number(isoDate[3]));
+  }
+
+  const enGbDate = startDate.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (enGbDate) {
+    return new Date(Number(enGbDate[3]), Number(enGbDate[2]) - 1, Number(enGbDate[1]));
+  }
+
+  return undefined;
+};
+
+const parseNotificationDate = (dateStr: string): Date | undefined => {
+  const parsedDate = new Date(Date.parse(dateStr));
+  return Number.isNaN(parsedDate.getTime()) ? undefined : parsedDate;
+};
+
+const parseNotificationFilterDate = (dateValue: string | undefined, optionName: string): Date | undefined => {
+  if (typeof dateValue === 'undefined') {
+    return undefined;
+  }
+
+  const parsedDate = parseDateOnly(dateValue) || parseNotificationDate(dateValue);
+
+  if (!parsedDate) {
+    throw new Error(`Invalid ${optionName} "${dateValue}". Use a date like 2026-05-31, 31/05/2026, or 2026-05-31T12:00:00Z.`);
+  }
+
+  return parsedDate;
+};
+
 const builder = (yargs: yargs.Argv<CommonConfig>) => {
   return yargs
     .positional('action', {
       describe: 'Optional info to lookup from your company',
       type: 'string',
-      choices: ['fleet', 'flights', 'fbos', 'jobs', 'income', 'cashflow', 'cash-flow', 'work-orders', 'trading-goods', 'trading_goods'],
+      choices: ['fleet', 'flights', 'fbos', 'jobs', 'income', 'cashflow', 'cash-flow', 'notifications', 'work-orders', 'trading-goods', 'trading_goods'],
     })
     .option('page', {
-      'describe': 'Page number (flights only)',
+      'describe': 'Page number (flights and notifications only)',
       'type': 'number',
       'alias': 'p',
+    })
+    .option('limit', {
+      describe: 'Number of notifications to display (notifications only)',
+      type: 'number',
+      default: 20,
+    })
+    .option('pages', {
+      describe: 'Number of notification pages to fetch (notifications only)',
+      type: 'number',
+    })
+    .option('start-date', {
+      describe: 'Fetch notifications from now back to this date (notifications only)',
+      type: 'string',
+    })
+    .option('end-date', {
+      describe: 'Filter notifications through this date (notifications only)',
+      type: 'string',
     })
     .option('days', {
       'describe': 'Days to display (Income statement only)',
@@ -250,6 +302,12 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
       default: false,
     })
     .example('$0 company','Get summary information for your company')
+    .example('$0 company notifications', 'Display your company notifications')
+    .example('$0 company notifications --limit=50', 'Display up to 50 company notifications')
+    .example('$0 company notifications --page=2', 'Display page 2 of company notifications')
+    .example('$0 company notifications --limit=50 --pages=3', 'Display three pages of company notifications')
+    .example('$0 company notifications --start-date=2026-05-31', 'Display notifications from now back to May 31, 2026')
+    .example('$0 company notifications --start-date=2026-05-01 --end-date=2026-05-31', 'Display notifications in a date range')
     .example('$0 company fleet','List your aircraft')
     .example('$0 company fleet --aircraft-type=airbus', 'List only matching aircraft types')
     .example('$0 company fleet --airport-icao=KJFK', 'List only aircraft at an airport')
@@ -411,6 +469,70 @@ export const companyCommand: CompanyCommand = {
             const priorDateStr = new Date(priorDate).toISOString();
             const income: IncomeStatement = await api.getCompanyIncomeStatement(priorDateStr, currentDateStr);    
             logCompanyIncome(income, daysToDisplay);
+            break;
+          }
+
+          case 'notifications': {
+            const notificationLimit = typeof argv['limit'] === 'number' && argv['limit'] > 0 ? argv['limit'] : 20;
+            const notificationPage = typeof argv['page'] === 'undefined' || argv['page'] < 1 ? 1 : argv['page'];
+            const notificationStartDate = parseNotificationFilterDate(argv['start-date'], 'start date');
+            const notificationEndDate = parseNotificationFilterDate(argv['end-date'], 'end date');
+            if (notificationStartDate && notificationEndDate && notificationStartDate > notificationEndDate) {
+              throw new Error('Start date must be before or equal to end date.');
+            }
+            const notificationPages = typeof argv['pages'] === 'number' && argv['pages'] > 0
+              ? Math.floor(argv['pages'])
+              : notificationStartDate ? Number.MAX_SAFE_INTEGER : 1;
+            const notifications: CompanyNotification[] = [];
+
+            for (let pageOffset = 0; pageOffset < notificationPages; pageOffset++) {
+              const pageToFetch = notificationPage + pageOffset;
+              const startIndex = (pageToFetch - 1) * notificationLimit;
+              const pageNotifications = await getCompanyNotifications(
+                argv['companyId'],
+                argv['apiKey'],
+                startIndex,
+                notificationLimit
+              );
+
+              notifications.push(...pageNotifications);
+
+              const reachedStartDate = notificationStartDate
+                ? pageNotifications.some((notification) => {
+                  const eventDate = parseNotificationDate(notification.ZuluEventTime);
+                  return typeof eventDate !== 'undefined' && eventDate < notificationStartDate;
+                })
+                : false;
+
+              if (pageNotifications.length < notificationLimit || reachedStartDate) {
+                break;
+              }
+            }
+
+            const filteredNotifications = notificationStartDate || notificationEndDate
+              ? notifications.filter((notification) => {
+                const eventDate = parseNotificationDate(notification.ZuluEventTime);
+                return typeof eventDate !== 'undefined'
+                  && (!notificationStartDate || eventDate >= notificationStartDate)
+                  && (!notificationEndDate || eventDate <= notificationEndDate);
+              })
+              : notifications;
+
+            if (filteredNotifications.length) {
+              const pagesLabel = notificationPages === Number.MAX_SAFE_INTEGER
+                ? 'until start date'
+                : `${notificationPages} page${notificationPages > 1 ? 's' : ''} requested`;
+              const startDateLabel = notificationStartDate ? `, since ${notificationStartDate.toLocaleString('en-GB')}` : '';
+              const endDateLabel = notificationEndDate ? `, through ${notificationEndDate.toLocaleString('en-GB')}` : '';
+              log(chalk.greenBright.bold(`Your company notifications (Page ${notificationPage}, ${notificationLimit} per page, ${pagesLabel}${startDateLabel}${endDateLabel})\n`));
+              logCompanyNotifications(filteredNotifications);
+
+              if (!notificationStartDate && filteredNotifications.length === notificationLimit * notificationPages) {
+                log(`\nSuggested command: ${argv['$0']} company notifications --page=${notificationPage + notificationPages} --limit=${notificationLimit} --pages=${notificationPages}`);
+              }
+            } else {
+              log('No company notifications found.');
+            }
             break;
           }
 

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -3,7 +3,11 @@ import chalk from 'chalk';
 import OnAirApi, { OnAirApiConfig, Company, Aircraft, Flight, Fbo, Job, IncomeStatement } from 'onair-api';
 
 import { getCompanyWorkOrders } from '../api/getCompanyWorkOrders';
-import { logCompanyWorkOrders, getWorkOrderAircraftIcao } from '../loggers/logCompanyWorkOrders';
+import {
+  logCompanyWorkOrders,
+  getWorkOrderAircraftIcao,
+  getWorkOrderAircraftIdentifier,
+} from '../loggers/logCompanyWorkOrders';
 import { CompanyWorkOrder } from '../types/CompanyWorkOrder';
 import { CommonConfig } from '../utils/commonTypes';
 import { logFlights } from '../loggers/logFlights';
@@ -48,6 +52,10 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
       'describe': 'Filter work orders by aircraft ICAO (work-orders only)',
       'type': 'string',
     })
+    .option('aircraft-ident', {
+      'describe': 'Filter work orders by aircraft identifier (work-orders only)',
+      'type': 'string',
+    })
     .option('show-crew', {
       'describe': 'Display assigned crew for work orders',
       'type': 'boolean',
@@ -71,6 +79,7 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .example('$0 company income --days=30', 'Display your statement summary for the last 30 days')
     .example('$0 company work-orders', 'List your company work orders')
     .example('$0 company work-orders --aircraft-icao=C172', 'List work orders for one aircraft ICAO')
+    .example('$0 company work-orders --aircraft-ident=N123AB', 'List work orders for one aircraft identifier')
     .example('$0 company work-orders --show-crew', 'List work orders with assigned crew names')
     .example('$0 company work-orders --work-order-id', 'List work orders including the work order ID');
 }
@@ -199,13 +208,19 @@ export const companyCommand: CompanyCommand = {
             const aircraftIcaoFilter = typeof argv['aircraft-icao'] === 'string'
               ? argv['aircraft-icao'].trim().toLocaleUpperCase()
               : undefined;
+            const aircraftIdentFilter = typeof argv['aircraft-ident'] === 'string'
+              ? argv['aircraft-ident'].trim().toLocaleUpperCase()
+              : undefined;
 
             const filteredWorkOrders = workOrders.filter((workOrder) => {
-              if (!aircraftIcaoFilter) {
-                return true;
-              }
+              const matchesAircraftIcao = aircraftIcaoFilter
+                ? getWorkOrderAircraftIcao(workOrder)?.toLocaleUpperCase() === aircraftIcaoFilter
+                : true;
+              const matchesAircraftIdent = aircraftIdentFilter
+                ? getWorkOrderAircraftIdentifier(workOrder)?.toLocaleUpperCase() === aircraftIdentFilter
+                : true;
 
-              return getWorkOrderAircraftIcao(workOrder)?.toLocaleUpperCase() === aircraftIcaoFilter;
+              return matchesAircraftIcao && matchesAircraftIdent;
             });
 
             if (filteredWorkOrders.length) {
@@ -213,7 +228,7 @@ export const companyCommand: CompanyCommand = {
               logCompanyWorkOrders(filteredWorkOrders, argv['show-crew'], argv['work-order-id']);
             } else {
               log(workOrders.length
-                ? 'No work orders matched your aircraft ICAO filter.'
+                ? 'No work orders matched your aircraft filters.'
                 : 'No work orders found.');
             }
             break;

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -1,6 +1,6 @@
 import yargs, { BuilderCallback, CommandModule } from 'yargs';
 import chalk from 'chalk';
-import OnAirApi, { OnAirApiConfig, Company, Aircraft, Flight, Fbo, Job, IncomeStatement } from 'onair-api';
+import OnAirApi, { OnAirApiConfig, Company, Aircraft, Flight, Fbo, Job, IncomeStatement, CashFlow } from 'onair-api';
 
 import { CompanyTradingGood, getCompanyTradingGoods } from '../api/getCompanyTradingGoods';
 import { getCompanyWorkOrders } from '../api/getCompanyWorkOrders';
@@ -15,6 +15,7 @@ import { logCompanyFbos } from '../loggers/logCompanyFbos';
 import { logCompanyFboJobs } from '../loggers/logCompanyFboJobs';
 import { logCompanyJobs } from '../loggers/logCompanyJobs';
 import { logCompanyIncome } from '../loggers/logCompanyIncome';
+import { logCompanyCashFlow } from '../loggers/logCompanyCashFlow';
 
 const log = console.log;
 
@@ -92,7 +93,7 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .positional('action', {
       describe: 'Optional info to lookup from your company',
       type: 'string',
-      choices: ['fleet', 'flights', 'fbos', 'jobs', 'income', 'work-orders', 'trading-goods', 'trading_goods'],
+      choices: ['fleet', 'flights', 'fbos', 'jobs', 'income', 'cashflow', 'cash-flow', 'work-orders', 'trading-goods', 'trading_goods'],
     })
     .option('page', {
       'describe': 'Page number (flights only)',
@@ -174,6 +175,7 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .example('$0 company jobs', 'List your pending jobs')
     .example('$0 company income', 'Display your company income statement summary')
     .example('$0 company income --days=30', 'Display your statement summary for the last 30 days')
+    .example('$0 company cashflow', 'Display your company cashflow')
     .example('$0 company work-orders', 'List your company work orders')
     .example('$0 company work-orders --aircraft-icao=C172', 'List work orders for one aircraft ICAO')
     .example('$0 company work-orders --show-crew', 'List work orders with assigned crew names')
@@ -318,6 +320,18 @@ export const companyCommand: CompanyCommand = {
             const priorDateStr = new Date(priorDate).toISOString();
             const income: IncomeStatement = await api.getCompanyIncomeStatement(priorDateStr, currentDateStr);    
             logCompanyIncome(income, daysToDisplay);
+            break;
+          }
+
+          case 'cashflow':
+          case 'cash-flow': {
+            const cashFlow: CashFlow = await api.getCompanyCashFlow();
+            if (cashFlow.Entries.length) {
+              log(chalk.greenBright.bold('Your cashflow\n'));
+              logCompanyCashFlow(cashFlow);
+            } else {
+              log('No cashflow entries found.');
+            }
             break;
           }
 

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -1,6 +1,6 @@
 import yargs, { BuilderCallback, CommandModule } from 'yargs';
 import chalk from 'chalk';
-import OnAirApi, { OnAirApiConfig, Company, Aircraft, Flight, Fbo, Job, IncomeStatement, CashFlow } from 'onair-api';
+import OnAirApi, { OnAirApiConfig, Company, Aircraft, Flight, Fbo, Job, IncomeStatement, CashFlow, BalanceSheet, Account } from 'onair-api';
 
 import { CompanyTradingGood, getCompanyTradingGoods } from '../api/getCompanyTradingGoods';
 import { getCompanyWorkOrders } from '../api/getCompanyWorkOrders';
@@ -15,7 +15,7 @@ import { logCompanyFbos } from '../loggers/logCompanyFbos';
 import { logCompanyFboJobs } from '../loggers/logCompanyFboJobs';
 import { logCompanyJobs } from '../loggers/logCompanyJobs';
 import { logCompanyIncome } from '../loggers/logCompanyIncome';
-import { CashFlowPaymentEntry, logCompanyCashFlow, logCompanyCashFlowPayments } from '../loggers/logCompanyCashFlow';
+import { AccountLookup, CashFlowPaymentEntry, logCompanyCashFlow, logCompanyCashFlowPayments } from '../loggers/logCompanyCashFlow';
 
 const log = console.log;
 
@@ -98,11 +98,73 @@ const isPaymentEntry = (entry: CashFlowPaymentEntry, paymentFilter?: string): bo
     : true;
 };
 
-const getAircraftLookup = (aircraft: Aircraft[]): Record<string, string> => {
+const addAircraftToLookup = (lookup: Record<string, string>, aircraft: Aircraft[]): Record<string, string> => {
   return aircraft.reduce((lookup, fleetAircraft) => {
     lookup[fleetAircraft.Id] = fleetAircraft.Identifier;
     return lookup;
-  }, {} as Record<string, string>);
+  }, lookup);
+};
+
+const getAircraftIds = (entries: CashFlowPaymentEntry[]): string[] => {
+  return Array.from(new Set(entries
+    .map((entry) => entry.AircraftId)
+    .filter((aircraftId): aircraftId is string => typeof aircraftId === 'string' && Boolean(aircraftId))));
+};
+
+const getAircraftLookup = async (api: OnAirApi, entries: CashFlowPaymentEntry[]): Promise<Record<string, string>> => {
+  const lookup = addAircraftToLookup({}, await api.getCompanyFleet());
+  const missingAircraftIds = getAircraftIds(entries).filter((aircraftId) => !lookup[aircraftId]);
+  const batchSize = 10;
+
+  for (let index = 0; index < missingAircraftIds.length; index += batchSize) {
+    const aircraftBatch = missingAircraftIds.slice(index, index + batchSize);
+    const resolvedAircraft = await Promise.all(aircraftBatch.map(async (aircraftId) => {
+      try {
+        const aircraft = await api.getAircraft(aircraftId);
+        return { aircraftId, identifier: aircraft.Identifier };
+      } catch (e) {
+        return { aircraftId, identifier: aircraftId };
+      }
+    }));
+
+    resolvedAircraft.forEach((aircraft) => {
+      lookup[aircraft.aircraftId] = aircraft.identifier;
+    });
+  }
+
+  return lookup;
+};
+
+const getAccountLabel = (account: Account): string => {
+  return account.ShortName ? `${account.Name} (${account.ShortName})` : account.Name;
+};
+
+const addAccountsToLookup = (lookup: AccountLookup, accounts: Account[]): AccountLookup => {
+  accounts.forEach((account) => {
+    account.Entries.forEach((entry) => {
+      lookup[entry.AccountId] = getAccountLabel(account);
+
+      const entryAccount = Array.isArray(entry.Account) ? entry.Account[0] : entry.Account;
+      if (entryAccount?.Id) {
+        lookup[entryAccount.Id] = entryAccount.ShortName
+          ? `${entryAccount.Name} (${entryAccount.ShortName})`
+          : entryAccount.Name;
+      }
+    });
+  });
+
+  return lookup;
+};
+
+const getAccountLookup = (income: IncomeStatement, balanceSheet: BalanceSheet): AccountLookup => {
+  const lookup: AccountLookup = {};
+
+  addAccountsToLookup(lookup, income.REVAccounts);
+  addAccountsToLookup(lookup, income.EXPAccounts);
+  addAccountsToLookup(lookup, balanceSheet.ASSAccounts);
+  addAccountsToLookup(lookup, balanceSheet.LIAAccounts);
+
+  return lookup;
 };
 
 const builder = (yargs: yargs.Argv<CommonConfig>) => {
@@ -182,6 +244,11 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
       describe: 'Show cashflow payment entries, optionally filtered by text such as Cargo or PAX (cashflow only)',
       type: 'string',
     })
+    .option('readable-account-ids', {
+      describe: 'Show cashflow account names where available instead of raw account IDs (cashflow only)',
+      type: 'boolean',
+      default: false,
+    })
     .example('$0 company','Get summary information for your company')
     .example('$0 company fleet','List your aircraft')
     .example('$0 company fleet --aircraft-type=airbus', 'List only matching aircraft types')
@@ -199,6 +266,7 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .example('$0 company cashflow', 'Display your company cashflow')
     .example('$0 company cashflow --payment=Cargo', 'Display cashflow payment entries matching Cargo')
     .example('$0 company cashflow --payment=PAX', 'Display cashflow payment entries matching PAX')
+    .example('$0 company cashflow --readable-account-ids', 'Display cashflow with readable account names where available')
     .example('$0 company work-orders', 'List your company work orders')
     .example('$0 company work-orders --aircraft-icao=C172', 'List work orders for one aircraft ICAO')
     .example('$0 company work-orders --show-crew', 'List work orders with assigned crew names')
@@ -352,15 +420,29 @@ export const companyCommand: CompanyCommand = {
             const paymentFilter = typeof argv['payment'] === 'string' && argv['payment'].trim()
               ? argv['payment'].trim()
               : undefined;
+            const readableAccountIds = Boolean(argv['readable-account-ids']);
+            const cashFlowEntries = cashFlow.Entries as CashFlowPaymentEntry[];
+            const aircraftLookup = readableAccountIds || typeof argv['payment'] !== 'undefined'
+              ? await getAircraftLookup(api, cashFlowEntries)
+              : {};
+            let accountLookup: AccountLookup = {};
+
+            if (readableAccountIds) {
+              const currentDate = new Date();
+              const currentDateStr = currentDate.toISOString();
+              const priorDate = new Date().setDate(currentDate.getDate() - 30);
+              const priorDateStr = new Date(priorDate).toISOString();
+              const income: IncomeStatement = await api.getCompanyIncomeStatement(priorDateStr, currentDateStr);
+              const balanceSheet: BalanceSheet = await api.getCompanyBalanceSheet();
+              accountLookup = getAccountLookup(income, balanceSheet);
+            }
 
             if (typeof argv['payment'] !== 'undefined') {
-              const paymentEntries = (cashFlow.Entries as CashFlowPaymentEntry[])
-                .filter((entry) => isPaymentEntry(entry, paymentFilter));
+              const paymentEntries = cashFlowEntries.filter((entry) => isPaymentEntry(entry, paymentFilter));
 
               if (paymentEntries.length) {
-                const companyFleet: Aircraft[] = await api.getCompanyFleet();
                 log(chalk.greenBright.bold('Your cashflow payments\n'));
-                logCompanyCashFlowPayments(paymentEntries, getAircraftLookup(companyFleet));
+                logCompanyCashFlowPayments(paymentEntries, aircraftLookup, readableAccountIds, accountLookup);
               } else {
                 log(paymentFilter
                   ? `No cashflow payment entries matched "${paymentFilter}".`
@@ -368,7 +450,7 @@ export const companyCommand: CompanyCommand = {
               }
             } else if (cashFlow.Entries.length) {
               log(chalk.greenBright.bold('Your cashflow\n'));
-              logCompanyCashFlow(cashFlow);
+              logCompanyCashFlow(cashFlow, readableAccountIds, aircraftLookup, accountLookup);
             } else {
               log('No cashflow entries found.');
             }

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -11,6 +11,7 @@ import { getCompanyWorkOrders } from '../api/getCompanyWorkOrders';
 import { logCompanyTradingGoods, logCompanyTradingGoodsSummary } from '../loggers/logCompanyTradingGoods';
 import {
   logCompanyWorkOrders,
+  logCompanyWorkOrderDetails,
   getWorkOrderAircraftIcao,
   getWorkOrderAircraftIdentifier,
 } from '../loggers/logCompanyWorkOrders';
@@ -292,6 +293,10 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
       'type': 'boolean',
       'default': false,
     })
+    .option('work-order-detail', {
+      'describe': 'Display detailed information for one work order ID',
+      'type': 'string',
+    })
     .option('merchandiseType', {
       describe: 'Filter trading goods by MerchandiseType.Name',
       type: 'string',
@@ -390,6 +395,7 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .example('$0 company work-orders --aircraft-ident=N123AB', 'List work orders for one aircraft identifier')
     .example('$0 company work-orders --show-crew', 'List work orders with assigned crew names')
     .example('$0 company work-orders --work-order-id', 'List work orders including the work order ID')
+    .example('$0 company work-orders --work-order-detail=WORK_ORDER_ID', 'Display details for one work order ID')
     .example('$0 company trading-goods', 'List your trading goods')
     .example('$0 company trading_goods --merchandiseType=Water', 'Filter trading goods by merchandise type name')
     .example('$0 company trading_goods --trading-airport-icao=KJFK', 'Filter trading goods by airport ICAO')
@@ -670,6 +676,23 @@ export const companyCommand: CompanyCommand = {
 
           case 'work-orders': {
             const workOrders: CompanyWorkOrder[] = await getCompanyWorkOrders(argv['companyId'], argv['apiKey']);
+            const workOrderDetailId = typeof argv['work-order-detail'] === 'string'
+              ? argv['work-order-detail'].trim()
+              : undefined;
+
+            if (workOrderDetailId) {
+              const detailedWorkOrder = workOrders.find((workOrder) => {
+                return workOrder.Id?.toLocaleLowerCase() === workOrderDetailId.toLocaleLowerCase();
+              });
+
+              if (detailedWorkOrder) {
+                logCompanyWorkOrderDetails(detailedWorkOrder);
+              } else {
+                log(`No work order found with ID "${workOrderDetailId}".`);
+              }
+              break;
+            }
+
             const aircraftIcaoFilter = typeof argv['aircraft-icao'] === 'string'
               ? argv['aircraft-icao'].trim().toLocaleUpperCase()
               : undefined;

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -4,7 +4,7 @@ import OnAirApi, { OnAirApiConfig, Company, Aircraft, Flight, Fbo, Job, IncomeSt
 
 import { CompanyTradingGood, getCompanyTradingGoods } from '../api/getCompanyTradingGoods';
 import { getCompanyWorkOrders } from '../api/getCompanyWorkOrders';
-import { logCompanyTradingGoods } from '../loggers/logCompanyTradingGoods';
+import { logCompanyTradingGoods, logCompanyTradingGoodsSummary } from '../loggers/logCompanyTradingGoods';
 import { logCompanyWorkOrders, getWorkOrderAircraftIcao } from '../loggers/logCompanyWorkOrders';
 import { CompanyWorkOrder } from '../types/CompanyWorkOrder';
 import { CommonConfig } from '../utils/commonTypes';
@@ -137,6 +137,7 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .option('trading-airport-icao', {
       describe: 'Filter trading goods by CurrentAirport.ICAO',
       type: 'string',
+      alias: 'trading-airport',
     })
     .option('hide-ids', {
       describe: 'Hide raw ID columns for trading goods',
@@ -145,6 +146,11 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     })
     .option('readable-ids', {
       describe: 'Swap trading goods ID columns to readable values where possible',
+      type: 'boolean',
+      default: false,
+    })
+    .option('summary', {
+      describe: 'Show a single-line summary for each trading good',
       type: 'boolean',
       default: false,
     })
@@ -167,7 +173,8 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .example('$0 company trading_goods --merchandiseType=Water', 'Filter trading goods by merchandise type name')
     .example('$0 company trading_goods --trading-airport-icao=KJFK', 'Filter trading goods by airport ICAO')
     .example('$0 company trading_goods --hide-ids', 'Hide raw ID columns for trading goods')
-    .example('$0 company trading_goods --readable-ids', 'Show human readable values instead of raw trading goods IDs');
+    .example('$0 company trading_goods --readable-ids', 'Show human readable values instead of raw trading goods IDs')
+    .example('$0 company trading_goods --summary', 'Show a single-line summary for each trading good');
 }
 
 type CompanyCommand = (typeof builder) extends BuilderCallback<CommonConfig, infer R> ? CommandModule<CommonConfig, R> : never;
@@ -328,7 +335,11 @@ export const companyCommand: CompanyCommand = {
 
             if (sortedTradingGoods.length) {
               log(chalk.greenBright.bold('Your Trading Goods\n'));
-              logCompanyTradingGoods(sortedTradingGoods, argv['hide-ids'], argv['readable-ids']);
+              if (argv['summary']) {
+                logCompanyTradingGoodsSummary(sortedTradingGoods);
+              } else {
+                logCompanyTradingGoods(sortedTradingGoods, argv['hide-ids'], argv['readable-ids']);
+              }
             } else {
               log(
                 argv['merchandiseType'] || argv['trading-airport-icao']

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -205,6 +205,12 @@ const parseNotificationFilterDate = (dateValue: string | undefined, optionName: 
   return parsedDate;
 };
 
+const jobHasDestinationIcao = (job: Job, destinationIcao: string): boolean => {
+  return [...job.Cargos, ...job.Charters].some((leg) => {
+    return leg.DestinationAirport?.ICAO?.toLocaleUpperCase() === destinationIcao;
+  });
+};
+
 const builder = (yargs: yargs.Argv<CommonConfig>) => {
   return yargs
     .positional('action', {
@@ -296,6 +302,11 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
       type: 'boolean',
       default: false,
     })
+    .option('destination-icao', {
+      describe: 'Filter FBO jobs by destination airport ICAO (fbos --fbojobs only)',
+      type: 'string',
+      alias: 'destination',
+    })
     .option('payment', {
       describe: 'Show cashflow payment entries, optionally filtered by text such as Cargo or PAX (cashflow only)',
       type: 'string',
@@ -322,6 +333,7 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .example('$0 company fbos --airport-icao=KJFK', 'List FBOs for one airport')
     .example('$0 company fbos --fbojobs', 'List your FBOs with jobs grouped under each FBO')
     .example('$0 company fbos --fbojobs --airport-icao=KJFK', 'List FBO jobs for one airport')
+    .example('$0 company fbos --fbojobs --airport-icao=KJFK --destination-icao=KORD', 'List FBO jobs for one airport with legs to a destination')
     .example('$0 company jobs', 'List your pending jobs')
     .example('$0 company income', 'Display your company income statement summary')
     .example('$0 company income --days=30', 'Display your statement summary for the last 30 days')
@@ -437,10 +449,17 @@ export const companyCommand: CompanyCommand = {
             if (filteredFbos.length) {
               if (argv['fbojobs']) {
                 const apiKey = argv['apiKey'];
+                const destinationIcaoFilter = typeof argv['destination-icao'] === 'string'
+                  ? argv['destination-icao'].trim().toLocaleUpperCase()
+                  : undefined;
                 const companyFboJobs = await Promise.all(filteredFbos.map(async (fbo) => {
+                  const fboJobs = await getFboJobs(fbo.Id, apiKey);
+
                   return {
                     fbo,
-                    jobs: await getFboJobs(fbo.Id, apiKey),
+                    jobs: destinationIcaoFilter
+                      ? fboJobs.filter((job) => jobHasDestinationIcao(job, destinationIcaoFilter))
+                      : fboJobs,
                   };
                 }));
                 log(chalk.greenBright.bold('Your FBO Jobs\n'));

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -2,6 +2,9 @@ import yargs, { BuilderCallback, CommandModule } from 'yargs';
 import chalk from 'chalk';
 import OnAirApi, { OnAirApiConfig, Company, Aircraft, Flight, Fbo, Job, IncomeStatement } from 'onair-api';
 
+import { getCompanyWorkOrders } from '../api/getCompanyWorkOrders';
+import { logCompanyWorkOrders, getWorkOrderAircraftIcao } from '../loggers/logCompanyWorkOrders';
+import { CompanyWorkOrder } from '../types/CompanyWorkOrder';
 import { CommonConfig } from '../utils/commonTypes';
 import { logFlights } from '../loggers/logFlights';
 import { logCompany } from '../loggers/logCompany';
@@ -17,7 +20,7 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .positional('action', {
       describe: 'Optional info to lookup from your company',
       type: 'string',
-      choices: ['fleet', 'flights', 'fbos', 'jobs', 'income'],
+      choices: ['fleet', 'flights', 'fbos', 'jobs', 'income', 'work-orders'],
     })
     .option('page', {
       'describe': 'Page number (flights only)',
@@ -28,14 +31,48 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
       'describe': 'Days to display (Income statement only)',
       'type': 'number',
     })
+    .option('aircraft-type', {
+      'describe': 'Filter fleet by aircraft type name (fleet only)',
+      'type': 'string',
+    })
+    .option('airport-icao', {
+      'describe': 'Filter fleet by current airport ICAO (fleet only)',
+      'type': 'string',
+    })
+    .option('sort', {
+      'describe': 'Sort fleet results',
+      'type': 'string',
+      'choices': ['aircraft-type'],
+    })
+    .option('aircraft-icao', {
+      'describe': 'Filter work orders by aircraft ICAO (work-orders only)',
+      'type': 'string',
+    })
+    .option('show-crew', {
+      'describe': 'Display assigned crew for work orders',
+      'type': 'boolean',
+      'default': false,
+    })
+    .option('work-order-id', {
+      'describe': 'Display work order IDs',
+      'type': 'boolean',
+      'default': false,
+    })
     .example('$0 company','Get summary information for your company')
     .example('$0 company fleet','List your aircraft')
+    .example('$0 company fleet --aircraft-type=airbus', 'List only matching aircraft types')
+    .example('$0 company fleet --airport-icao=KJFK', 'List only aircraft at an airport')
+    .example('$0 company fleet --sort=aircraft-type', 'Sort fleet by aircraft type')
     .example('$0 company flights','List your flights')
     .example('$0 company flights -p=2','List your flights, showing page 2')
     .example('$0 company fbos', 'List your FBOs')
     .example('$0 company jobs', 'List your pending jobs')
     .example('$0 company income', 'Display your company income statement summary')
-    .example('$0 company income --days=30', 'Display your statement summary for the last 30 days');
+    .example('$0 company income --days=30', 'Display your statement summary for the last 30 days')
+    .example('$0 company work-orders', 'List your company work orders')
+    .example('$0 company work-orders --aircraft-icao=C172', 'List work orders for one aircraft ICAO')
+    .example('$0 company work-orders --show-crew', 'List work orders with assigned crew names')
+    .example('$0 company work-orders --work-order-id', 'List work orders including the work order ID');
 }
 
 type CompanyCommand = (typeof builder) extends BuilderCallback<CommonConfig, infer R> ? CommandModule<CommonConfig, R> : never;
@@ -60,15 +97,42 @@ export const companyCommand: CompanyCommand = {
         switch (argv['action']) {
           case 'fleet': {
             const companyFleet: Aircraft[] = await api.getCompanyFleet();
-            if (companyFleet.length) {
+            const aircraftTypeFilter = typeof argv['aircraft-type'] === 'string'
+              ? argv['aircraft-type'].trim().toLocaleLowerCase()
+              : undefined;
+            const airportIcaoFilter = typeof argv['airport-icao'] === 'string'
+              ? argv['airport-icao'].trim().toLocaleUpperCase()
+              : undefined;
+
+            let filteredFleet = companyFleet.filter((aircraft) => {
+              const matchesAircraftType = aircraftTypeFilter
+                ? aircraft.AircraftType.DisplayName.toLocaleLowerCase().includes(aircraftTypeFilter)
+                : true;
+              const matchesAirportIcao = airportIcaoFilter
+                ? aircraft.CurrentAirport?.ICAO?.toLocaleUpperCase() === airportIcaoFilter
+                : true;
+
+              return matchesAircraftType && matchesAirportIcao;
+            });
+
+            if (argv['sort'] === 'aircraft-type') {
+              filteredFleet = [...filteredFleet].sort((a, b) => {
+                const typeSort = a.AircraftType.DisplayName.localeCompare(b.AircraftType.DisplayName);
+                return typeSort !== 0 ? typeSort : a.Identifier.localeCompare(b.Identifier);
+              });
+            }
+
+            if (filteredFleet.length) {
               log(chalk.greenBright.bold('Your fleet of aircraft\n'));
               
-              logCompanyFleet(companyFleet);
+              logCompanyFleet(filteredFleet);
               
               log(`\nSuggested command: ${argv['$0']} aircraft <aircraftId>`);
               log(`Suggested command: ${argv['$0']} flights <aircraftId>`);
             } else {
-              log('Dude, where\'s your aircraft?! ' + chalk.magentaBright('✈'));
+              log(companyFleet.length
+                ? 'No aircraft matched your fleet filters.'
+                : 'Dude, where\'s your aircraft?! ' + chalk.magentaBright('✈'));
             }
             break;
           } 
@@ -127,6 +191,32 @@ export const companyCommand: CompanyCommand = {
             const priorDateStr = new Date(priorDate).toISOString();
             const income: IncomeStatement = await api.getCompanyIncomeStatement(priorDateStr, currentDateStr);    
             logCompanyIncome(income, daysToDisplay);
+            break;
+          }
+
+          case 'work-orders': {
+            const workOrders: CompanyWorkOrder[] = await getCompanyWorkOrders(argv['companyId'], argv['apiKey']);
+            const aircraftIcaoFilter = typeof argv['aircraft-icao'] === 'string'
+              ? argv['aircraft-icao'].trim().toLocaleUpperCase()
+              : undefined;
+
+            const filteredWorkOrders = workOrders.filter((workOrder) => {
+              if (!aircraftIcaoFilter) {
+                return true;
+              }
+
+              return getWorkOrderAircraftIcao(workOrder)?.toLocaleUpperCase() === aircraftIcaoFilter;
+            });
+
+            if (filteredWorkOrders.length) {
+              log(chalk.greenBright.bold('Your work orders\n'));
+              logCompanyWorkOrders(filteredWorkOrders, argv['show-crew'], argv['work-order-id']);
+            } else {
+              log(workOrders.length
+                ? 'No work orders matched your aircraft ICAO filter.'
+                : 'No work orders found.');
+            }
+            break;
           }
         }
       }

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -12,6 +12,7 @@ import { logFlights } from '../loggers/logFlights';
 import { logCompany } from '../loggers/logCompany';
 import { logCompanyFleet } from '../loggers/logCompanyFleet';
 import { logCompanyFbos } from '../loggers/logCompanyFbos';
+import { logCompanyFboJobs } from '../loggers/logCompanyFboJobs';
 import { logCompanyJobs } from '../loggers/logCompanyJobs';
 import { logCompanyIncome } from '../loggers/logCompanyIncome';
 
@@ -107,7 +108,7 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
       'type': 'string',
     })
     .option('airport-icao', {
-      'describe': 'Filter fleet by current airport ICAO (fleet only)',
+      'describe': 'Filter fleet by current airport ICAO, or FBOs by airport ICAO',
       'type': 'string',
     })
     .option('sort', {
@@ -154,6 +155,11 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
       type: 'boolean',
       default: false,
     })
+    .option('fbojobs', {
+      describe: 'Show FBO jobs grouped by airport and FBO name (fbos only)',
+      type: 'boolean',
+      default: false,
+    })
     .example('$0 company','Get summary information for your company')
     .example('$0 company fleet','List your aircraft')
     .example('$0 company fleet --aircraft-type=airbus', 'List only matching aircraft types')
@@ -162,6 +168,9 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .example('$0 company flights','List your flights')
     .example('$0 company flights -p=2','List your flights, showing page 2')
     .example('$0 company fbos', 'List your FBOs')
+    .example('$0 company fbos --airport-icao=KJFK', 'List FBOs for one airport')
+    .example('$0 company fbos --fbojobs', 'List your FBOs with jobs grouped under each FBO')
+    .example('$0 company fbos --fbojobs --airport-icao=KJFK', 'List FBO jobs for one airport')
     .example('$0 company jobs', 'List your pending jobs')
     .example('$0 company income', 'Display your company income statement summary')
     .example('$0 company income --days=30', 'Display your statement summary for the last 30 days')
@@ -261,10 +270,26 @@ export const companyCommand: CompanyCommand = {
 
           case 'fbos': {
             const companyFbos: Fbo[] = await api.getCompanyFbos();
+            const airportIcaoFilter = typeof argv['airport-icao'] === 'string'
+              ? argv['airport-icao'].trim().toLocaleUpperCase()
+              : undefined;
+            const filteredFbos = companyFbos.filter((fbo) => {
+              return airportIcaoFilter
+                ? fbo.Airport?.ICAO?.toLocaleUpperCase() === airportIcaoFilter
+                : true;
+            });
             
-            if (companyFbos.length) {
-              log(chalk.greenBright.bold('Your FBOs\n'));
-              logCompanyFbos(companyFbos);
+            if (filteredFbos.length) {
+              if (argv['fbojobs']) {
+                const companyJobs: Job[] = await api.getCompanyJobs();
+                log(chalk.greenBright.bold('Your FBO Jobs\n'));
+                logCompanyFboJobs(filteredFbos, companyJobs);
+              } else {
+                log(chalk.greenBright.bold('Your FBOs\n'));
+                logCompanyFbos(filteredFbos);
+              }
+            } else if (companyFbos.length && airportIcaoFilter) {
+              log('No FBOs matched your airport ICAO filter.');
             } else {
               log('No FBO... no 100LL! ' + chalk.magentaBright('✈'))
             }

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -14,6 +14,8 @@ import {
   logCompanyWorkOrderDetails,
   getWorkOrderAircraftIcao,
   getWorkOrderAircraftIdentifier,
+  matchesWorkOrderStatus,
+  WORK_ORDER_STATUS_FILTERS,
 } from '../loggers/logCompanyWorkOrders';
 import { CompanyWorkOrder } from '../types/CompanyWorkOrder';
 import { CommonConfig } from '../utils/commonTypes';
@@ -283,6 +285,11 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
       'describe': 'Filter work orders by aircraft identifier (work-orders only)',
       'type': 'string',
     })
+    .option('work-order-status', {
+      'describe': 'Filter work orders by status',
+      'type': 'string',
+      'choices': [...WORK_ORDER_STATUS_FILTERS],
+    })
     .option('show-crew', {
       'describe': 'Display assigned crew for work orders',
       'type': 'boolean',
@@ -393,6 +400,8 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .example('$0 company work-orders', 'List your company work orders')
     .example('$0 company work-orders --aircraft-icao=C172', 'List work orders for one aircraft ICAO')
     .example('$0 company work-orders --aircraft-ident=N123AB', 'List work orders for one aircraft identifier')
+    .example('$0 company work-orders --work-order-status=pending', 'List pending work orders')
+    .example('$0 company work-orders --work-order-status=in-progress', 'List work orders currently in progress')
     .example('$0 company work-orders --show-crew', 'List work orders with assigned crew names')
     .example('$0 company work-orders --work-order-id', 'List work orders including the work order ID')
     .example('$0 company work-orders --work-order-detail=WORK_ORDER_ID', 'Display details for one work order ID')
@@ -699,6 +708,9 @@ export const companyCommand: CompanyCommand = {
             const aircraftIdentFilter = typeof argv['aircraft-ident'] === 'string'
               ? argv['aircraft-ident'].trim().toLocaleUpperCase()
               : undefined;
+            const workOrderStatusFilter = typeof argv['work-order-status'] === 'string'
+              ? argv['work-order-status'].trim()
+              : undefined;
 
             const filteredWorkOrders = workOrders.filter((workOrder) => {
               const matchesAircraftIcao = aircraftIcaoFilter
@@ -708,7 +720,9 @@ export const companyCommand: CompanyCommand = {
                 ? getWorkOrderAircraftIdentifier(workOrder)?.toLocaleUpperCase() === aircraftIdentFilter
                 : true;
 
-              return matchesAircraftIcao && matchesAircraftIdent;
+              return matchesAircraftIcao
+                && matchesAircraftIdent
+                && matchesWorkOrderStatus(workOrder, workOrderStatusFilter);
             });
 
             if (filteredWorkOrders.length) {
@@ -716,7 +730,7 @@ export const companyCommand: CompanyCommand = {
               logCompanyWorkOrders(filteredWorkOrders, argv['show-crew'], argv['work-order-id']);
             } else {
               log(workOrders.length
-                ? 'No work orders matched your aircraft filters.'
+                ? 'No work orders matched the selected filters.'
                 : 'No work orders found.');
             }
             break;

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -16,7 +16,7 @@ import { logFlights } from '../loggers/logFlights';
 import { logCompany } from '../loggers/logCompany';
 import { logCompanyFleet } from '../loggers/logCompanyFleet';
 import { logCompanyFbos } from '../loggers/logCompanyFbos';
-import { logCompanyFboJobs } from '../loggers/logCompanyFboJobs';
+import { logCompanyFboJobDestinations, logCompanyFboJobs } from '../loggers/logCompanyFboJobs';
 import { logCompanyJobs } from '../loggers/logCompanyJobs';
 import { logCompanyIncome } from '../loggers/logCompanyIncome';
 import { AccountLookup, CashFlowPaymentEntry, logCompanyCashFlow, logCompanyCashFlowPayments } from '../loggers/logCompanyCashFlow';
@@ -307,6 +307,12 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
       type: 'string',
       alias: 'destination',
     })
+    .option('list-destinations', {
+      describe: 'List available destination ICAOs for FBO jobs (fbos --fbojobs only)',
+      type: 'boolean',
+      alias: 'destinations',
+      default: false,
+    })
     .option('payment', {
       describe: 'Show cashflow payment entries, optionally filtered by text such as Cargo or PAX (cashflow only)',
       type: 'string',
@@ -334,6 +340,7 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .example('$0 company fbos --fbojobs', 'List your FBOs with jobs grouped under each FBO')
     .example('$0 company fbos --fbojobs --airport-icao=KJFK', 'List FBO jobs for one airport')
     .example('$0 company fbos --fbojobs --airport-icao=KJFK --destination-icao=KORD', 'List FBO jobs for one airport with legs to a destination')
+    .example('$0 company fbos --fbojobs --airport-icao=KJFK --list-destinations', 'List available FBO job destination ICAOs for one airport')
     .example('$0 company jobs', 'List your pending jobs')
     .example('$0 company income', 'Display your company income statement summary')
     .example('$0 company income --days=30', 'Display your statement summary for the last 30 days')
@@ -462,6 +469,12 @@ export const companyCommand: CompanyCommand = {
                       : fboJobs,
                   };
                 }));
+                if (argv['list-destinations']) {
+                  log(chalk.greenBright.bold('Your FBO Job Destinations\n'));
+                  logCompanyFboJobDestinations(companyFboJobs);
+                  break;
+                }
+
                 log(chalk.greenBright.bold('Your FBO Jobs\n'));
                 logCompanyFboJobs(companyFboJobs);
               } else {

--- a/src/commands/company.ts
+++ b/src/commands/company.ts
@@ -211,6 +211,18 @@ const jobHasDestinationIcao = (job: Job, destinationIcao: string): boolean => {
   });
 };
 
+const isFuelBelowHalf = (quantity: number, capacity: number): boolean => {
+  return capacity > 0 && quantity < capacity / 2;
+};
+
+const fboNeedsFuel = (fbo: Fbo, needs100LL: boolean, needsJet: boolean): boolean => {
+  const check100LL = needs100LL || !needsJet;
+  const checkJet = needsJet || !needs100LL;
+
+  return (check100LL && isFuelBelowHalf(fbo.Fuel100LLQuantity, fbo.Fuel100LLCapacity))
+    || (checkJet && isFuelBelowHalf(fbo.FuelJetQuantity, fbo.FuelJetCapacity));
+};
+
 const builder = (yargs: yargs.Argv<CommonConfig>) => {
   return yargs
     .positional('action', {
@@ -302,6 +314,21 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
       type: 'boolean',
       default: false,
     })
+    .option('need-fuel', {
+      describe: 'Show only FBOs with less than 50% fuel available (fbos only)',
+      type: 'boolean',
+      default: false,
+    })
+    .option('100LL', {
+      describe: 'Filter --need-fuel to 100LL fuel (fbos only)',
+      type: 'boolean',
+      default: false,
+    })
+    .option('Jet', {
+      describe: 'Filter --need-fuel to Jet fuel (fbos only)',
+      type: 'boolean',
+      default: false,
+    })
     .option('destination-icao', {
       describe: 'Filter FBO jobs by destination airport ICAO (fbos --fbojobs only)',
       type: 'string',
@@ -337,6 +364,8 @@ const builder = (yargs: yargs.Argv<CommonConfig>) => {
     .example('$0 company flights -p=2','List your flights, showing page 2')
     .example('$0 company fbos', 'List your FBOs')
     .example('$0 company fbos --airport-icao=KJFK', 'List FBOs for one airport')
+    .example('$0 company fbos --need-fuel --100LL', 'List FBOs with less than 50% 100LL available')
+    .example('$0 company fbos --need-fuel --Jet', 'List FBOs with less than 50% Jet fuel available')
     .example('$0 company fbos --fbojobs', 'List your FBOs with jobs grouped under each FBO')
     .example('$0 company fbos --fbojobs --airport-icao=KJFK', 'List FBO jobs for one airport')
     .example('$0 company fbos --fbojobs --airport-icao=KJFK --destination-icao=KORD', 'List FBO jobs for one airport with legs to a destination')
@@ -447,10 +476,19 @@ export const companyCommand: CompanyCommand = {
             const airportIcaoFilter = typeof argv['airport-icao'] === 'string'
               ? argv['airport-icao'].trim().toLocaleUpperCase()
               : undefined;
+            const needsFuelFilter = Boolean(argv['need-fuel']);
+            const needs100LLFilter = Boolean(argv['100LL']);
+            const needsJetFilter = Boolean(argv['Jet']);
             const filteredFbos = companyFbos.filter((fbo) => {
-              return airportIcaoFilter
+              const matchesAirportIcao = airportIcaoFilter
                 ? fbo.Airport?.ICAO?.toLocaleUpperCase() === airportIcaoFilter
                 : true;
+
+              const matchesFuelNeed = needsFuelFilter
+                ? fboNeedsFuel(fbo, needs100LLFilter, needsJetFilter)
+                : true;
+
+              return matchesAirportIcao && matchesFuelNeed;
             });
             
             if (filteredFbos.length) {
@@ -481,8 +519,8 @@ export const companyCommand: CompanyCommand = {
                 log(chalk.greenBright.bold('Your FBOs\n'));
                 logCompanyFbos(filteredFbos);
               }
-            } else if (companyFbos.length && airportIcaoFilter) {
-              log('No FBOs matched your airport ICAO filter.');
+            } else if (companyFbos.length && (airportIcaoFilter || needsFuelFilter)) {
+              log('No FBOs matched your FBO filters.');
             } else {
               log('No FBO... no 100LL! ' + chalk.magentaBright('✈'))
             }

--- a/src/loggers/logCompanyCashFlow.ts
+++ b/src/loggers/logCompanyCashFlow.ts
@@ -7,7 +7,18 @@ export interface CashFlowPaymentEntry extends CashFlowEntry {
   AircraftId?: string;
 }
 
+interface CashFlowAccount {
+  Id: string;
+  ShortName?: string;
+  Name?: string;
+}
+
+interface CashFlowEntryWithAccount extends CashFlowEntry {
+  Account?: CashFlowAccount | CashFlowAccount[];
+}
+
 export type AircraftLookup = Record<string, string>;
+export type AccountLookup = Record<string, string>;
 
 const formatMoney = (amount: number): string => {
   const formattedAmount = amount.toLocaleString('en-GB');
@@ -38,7 +49,35 @@ const getPaymentType = (description: string): string => {
   return match ? match[1].trim() : 'Payment';
 };
 
-export const logCompanyCashFlow = (cashFlow: CashFlow): void => {
+const getAircraftLabel = (entry: CashFlowPaymentEntry, aircraftLookup: AircraftLookup): string => {
+  return entry.AircraftId ? aircraftLookup[entry.AircraftId] || entry.AircraftId : '-';
+};
+
+const getAccountLabel = (entry: CashFlowEntry, accountLookup: AccountLookup = {}): string => {
+  const account = (entry as CashFlowEntryWithAccount).Account;
+  const accountValue = Array.isArray(account) ? account[0] : account;
+
+  if (accountValue?.Name && accountValue.ShortName) {
+    return `${accountValue.Name} (${accountValue.ShortName})`;
+  }
+
+  if (accountValue?.Name) {
+    return accountValue.Name;
+  }
+
+  if (accountValue?.ShortName) {
+    return accountValue.ShortName;
+  }
+
+  return accountLookup[entry.AccountId] || entry.AccountId;
+};
+
+export const logCompanyCashFlow = (
+  cashFlow: CashFlow,
+  readableAccountIds = false,
+  aircraftLookup: AircraftLookup = {},
+  accountLookup: AccountLookup = {}
+): void => {
   const summaryTable = cliTable();
 
   summaryTable.push([
@@ -60,6 +99,8 @@ export const logCompanyCashFlow = (cashFlow: CashFlow): void => {
   cashFlowTable.push([
     chalk.green('Date'),
     chalk.green('Description'),
+    ...(readableAccountIds ? [chalk.green('Aircraft')] : []),
+    ...(readableAccountIds ? [chalk.green('Account')] : []),
     chalk.green('Amount'),
     chalk.green('Carry Forward'),
   ]);
@@ -68,6 +109,8 @@ export const logCompanyCashFlow = (cashFlow: CashFlow): void => {
     cashFlowTable.push([
       formatDate(entry.CreationDate),
       entry.Description,
+      ...(readableAccountIds ? [getAircraftLabel(entry as CashFlowPaymentEntry, aircraftLookup)] : []),
+      ...(readableAccountIds ? [getAccountLabel(entry, accountLookup)] : []),
       formatMoney(entry.Amount),
       getCarryForward(entry),
     ]);
@@ -78,13 +121,16 @@ export const logCompanyCashFlow = (cashFlow: CashFlow): void => {
 
 export const logCompanyCashFlowPayments = (
   entries: CashFlowPaymentEntry[],
-  aircraftLookup: AircraftLookup = {}
+  aircraftLookup: AircraftLookup = {},
+  readableAccountIds = false,
+  accountLookup: AccountLookup = {}
 ): void => {
   const paymentTable = cliTable();
   paymentTable.push([
     chalk.green('Creation Date'),
     chalk.green('Payment'),
     chalk.green('Aircraft'),
+    ...(readableAccountIds ? [chalk.green('Account')] : []),
     chalk.green('Amount'),
   ]);
 
@@ -92,7 +138,8 @@ export const logCompanyCashFlowPayments = (
     paymentTable.push([
       formatDate(entry.CreationDate),
       getPaymentType(entry.Description),
-      entry.AircraftId ? aircraftLookup[entry.AircraftId] || entry.AircraftId : '-',
+      getAircraftLabel(entry, aircraftLookup),
+      ...(readableAccountIds ? [getAccountLabel(entry, accountLookup)] : []),
       formatMoney(entry.Amount),
     ]);
   });

--- a/src/loggers/logCompanyCashFlow.ts
+++ b/src/loggers/logCompanyCashFlow.ts
@@ -1,0 +1,65 @@
+import chalk from "chalk";
+import { CashFlow, CashFlowEntry } from "onair-api";
+
+import { cliTable } from "../utils/cli-table";
+
+const formatMoney = (amount: number): string => {
+  const formattedAmount = amount.toLocaleString('en-GB');
+
+  return amount < 0
+    ? chalk.red(formattedAmount)
+    : chalk.green(formattedAmount);
+};
+
+const formatDate = (dateStr: string): string => {
+  const date = new Date(Date.parse(dateStr));
+
+  return Number.isNaN(date.getTime()) ? dateStr : date.toLocaleString('en-GB');
+};
+
+const getCarryForward = (entry: CashFlowEntry): string => {
+  const cashFlowEntry = entry as CashFlowEntry & { CarryForward?: boolean; CarryFowarad?: boolean | string };
+  const carryForward = typeof cashFlowEntry.CarryForward !== 'undefined'
+    ? cashFlowEntry.CarryForward
+    : cashFlowEntry.CarryFowarad;
+
+  return carryForward ? 'Yes' : 'No';
+};
+
+export const logCompanyCashFlow = (cashFlow: CashFlow): void => {
+  const summaryTable = cliTable();
+
+  summaryTable.push([
+    chalk.green('Current Cash'),
+    formatMoney(cashFlow.CompanyCurrentCash),
+    chalk.green('Last Report Amount'),
+    formatMoney(cashFlow.LastReportAmount),
+  ]);
+  summaryTable.push([
+    chalk.green('Last Report Date'),
+    formatDate(cashFlow.LastReportDate),
+    '',
+    '',
+  ]);
+
+  console.log(summaryTable.toString() + '\n');
+
+  const cashFlowTable = cliTable();
+  cashFlowTable.push([
+    chalk.green('Date'),
+    chalk.green('Description'),
+    chalk.green('Amount'),
+    chalk.green('Carry Forward'),
+  ]);
+
+  cashFlow.Entries.forEach((entry) => {
+    cashFlowTable.push([
+      formatDate(entry.CreationDate),
+      entry.Description,
+      formatMoney(entry.Amount),
+      getCarryForward(entry),
+    ]);
+  });
+
+  console.log(cashFlowTable.toString());
+};

--- a/src/loggers/logCompanyCashFlow.ts
+++ b/src/loggers/logCompanyCashFlow.ts
@@ -3,6 +3,12 @@ import { CashFlow, CashFlowEntry } from "onair-api";
 
 import { cliTable } from "../utils/cli-table";
 
+export interface CashFlowPaymentEntry extends CashFlowEntry {
+  AircraftId?: string;
+}
+
+export type AircraftLookup = Record<string, string>;
+
 const formatMoney = (amount: number): string => {
   const formattedAmount = amount.toLocaleString('en-GB');
 
@@ -24,6 +30,12 @@ const getCarryForward = (entry: CashFlowEntry): string => {
     : cashFlowEntry.CarryFowarad;
 
   return carryForward ? 'Yes' : 'No';
+};
+
+const getPaymentType = (description: string): string => {
+  const match = description.match(/^Payment for ([^(\\.]+)/i);
+
+  return match ? match[1].trim() : 'Payment';
 };
 
 export const logCompanyCashFlow = (cashFlow: CashFlow): void => {
@@ -62,4 +74,28 @@ export const logCompanyCashFlow = (cashFlow: CashFlow): void => {
   });
 
   console.log(cashFlowTable.toString());
+};
+
+export const logCompanyCashFlowPayments = (
+  entries: CashFlowPaymentEntry[],
+  aircraftLookup: AircraftLookup = {}
+): void => {
+  const paymentTable = cliTable();
+  paymentTable.push([
+    chalk.green('Creation Date'),
+    chalk.green('Payment'),
+    chalk.green('Aircraft'),
+    chalk.green('Amount'),
+  ]);
+
+  entries.forEach((entry) => {
+    paymentTable.push([
+      formatDate(entry.CreationDate),
+      getPaymentType(entry.Description),
+      entry.AircraftId ? aircraftLookup[entry.AircraftId] || entry.AircraftId : '-',
+      formatMoney(entry.Amount),
+    ]);
+  });
+
+  console.log(paymentTable.toString());
 };

--- a/src/loggers/logCompanyFboJobs.ts
+++ b/src/loggers/logCompanyFboJobs.ts
@@ -8,6 +8,12 @@ export interface CompanyFboJobs {
   jobs: Job[];
 }
 
+interface DestinationSummary {
+  icao: string;
+  jobCount: number;
+  legCount: number;
+}
+
 type JobWithAirports = Job & {
   BaseAirport?: { ICAO?: string };
   MainAirport?: { ICAO?: string };
@@ -52,6 +58,37 @@ const getExpiresIn = (dateStr: string): string => {
 
 const getLegs = (job: Job): Array<Cargo | Charter> => {
   return [...job.Cargos, ...job.Charters];
+};
+
+const getDestinationSummaries = (jobs: Job[]): DestinationSummary[] => {
+  const destinationLookup: Record<string, { jobIds: Set<string>; legCount: number }> = {};
+
+  jobs.forEach((job) => {
+    getLegs(job).forEach((leg) => {
+      const icao = leg.DestinationAirport?.ICAO?.toLocaleUpperCase();
+      if (!icao) {
+        return;
+      }
+
+      destinationLookup[icao] = destinationLookup[icao] || { jobIds: new Set<string>(), legCount: 0 };
+      destinationLookup[icao].jobIds.add(job.Id);
+      destinationLookup[icao].legCount += 1;
+    });
+  });
+
+  return Object.entries(destinationLookup)
+    .map(([icao, summary]) => ({
+      icao,
+      jobCount: summary.jobIds.size,
+      legCount: summary.legCount,
+    }))
+    .sort((left, right) => {
+      if (right.jobCount !== left.jobCount) {
+        return right.jobCount - left.jobCount;
+      }
+
+      return left.icao.localeCompare(right.icao);
+    });
 };
 
 const formatNumber = (value: number): string => {
@@ -172,6 +209,39 @@ const getPayloadDescription = (routeGroups: RouteGroup[]): string => {
     .flatMap((group) => group.descriptions)
     .filter((description, index, descriptions) => descriptions.indexOf(description) === index)
     .join(', ');
+};
+
+export const logCompanyFboJobDestinations = (companyFboJobs: CompanyFboJobs[]): void => {
+  companyFboJobs.forEach(({ fbo, jobs }, index) => {
+    console.log(chalk.whiteBright.bold(`${fbo.Airport.ICAO} - ${fbo.Name}`));
+
+    const destinationSummaries = getDestinationSummaries(jobs);
+    if (!destinationSummaries.length) {
+      console.log(chalk.grey('No available destinations.\n'));
+      return;
+    }
+
+    const destinationTable = cliTable();
+    destinationTable.push([
+      chalk.green('Destination'),
+      chalk.green('Jobs'),
+      chalk.green('Legs'),
+    ]);
+
+    destinationSummaries.forEach((summary) => {
+      destinationTable.push([
+        summary.icao,
+        summary.jobCount,
+        summary.legCount,
+      ]);
+    });
+
+    console.log(destinationTable.toString());
+
+    if (index < companyFboJobs.length - 1) {
+      console.log('');
+    }
+  });
 };
 
 export const logCompanyFboJobs = (companyFboJobs: CompanyFboJobs[]): void => {

--- a/src/loggers/logCompanyFboJobs.ts
+++ b/src/loggers/logCompanyFboJobs.ts
@@ -1,0 +1,132 @@
+import chalk from 'chalk';
+import { Airport, Cargo, Charter, Fbo, Job } from 'onair-api';
+
+import { cliTable } from '../utils/cli-table';
+
+const getAirportIfMatchesBase = (airport: Airport | undefined, baseAirportId: string): Airport | undefined => {
+  return airport?.Id === baseAirportId ? airport : undefined;
+};
+
+const getJobBaseAirport = (job: Job): Airport | undefined => {
+  let baseAirport: Airport | undefined = (job as Job & { BaseAirport?: Airport }).BaseAirport;
+
+  if (!baseAirport && job.Cargos.length > 0) {
+    job.Cargos.find((cargo) => {
+      baseAirport =
+        getAirportIfMatchesBase(cargo.DepartureAirport, job.BaseAirportId)
+        || getAirportIfMatchesBase(cargo.CurrentAirport, job.BaseAirportId)
+        || getAirportIfMatchesBase(cargo.DestinationAirport, job.BaseAirportId);
+
+      return Boolean(baseAirport);
+    });
+  }
+
+  if (!baseAirport && job.Charters.length > 0) {
+    job.Charters.find((charter) => {
+      baseAirport =
+        getAirportIfMatchesBase(charter.DepartureAirport, job.BaseAirportId)
+        || getAirportIfMatchesBase(charter.CurrentAirport, job.BaseAirportId)
+        || getAirportIfMatchesBase(charter.DestinationAirport, job.BaseAirportId);
+
+      return Boolean(baseAirport);
+    });
+  }
+
+  return baseAirport;
+};
+
+const getExpiresIn = (dateStr: string): string => {
+  const dueDate = new Date(dateStr).getTime();
+  const now = Date.now();
+  const diffInMinutes = Math.round((dueDate - now) / 60000);
+
+  if (diffInMinutes <= 0) {
+    return chalk.red(`${diffInMinutes} mins`);
+  }
+
+  if (diffInMinutes <= 240) {
+    return chalk.yellow(`${diffInMinutes} mins`);
+  }
+
+  return chalk.green(`${diffInMinutes} mins`);
+};
+
+const getLegs = (job: Job): Array<Cargo | Charter> => {
+  return [...job.Cargos, ...job.Charters];
+};
+
+const formatHumanOnly = (leg: Cargo | Charter): string => {
+  return leg.HumanOnly ? 'Yes' : 'No';
+};
+
+export const logCompanyFboJobs = (companyFbos: Fbo[], companyJobs: Job[]): void => {
+  companyFbos.forEach((fbo, index) => {
+    const matchingJobs = companyJobs.filter((job) => {
+      if (job.BaseAirportId === fbo.AirportId) {
+        return true;
+      }
+
+      return getJobBaseAirport(job)?.Id === fbo.AirportId;
+    });
+
+    console.log(chalk.whiteBright.bold(`${fbo.Airport.ICAO} - ${fbo.Name}`));
+
+    if (!matchingJobs.length) {
+      console.log(chalk.grey('No pending jobs.\n'));
+      return;
+    }
+
+    const jobTable = cliTable();
+
+    jobTable.push([
+      chalk.green('Job Type'),
+      chalk.green('Description'),
+      chalk.green('Legs'),
+      chalk.green('Current'),
+      chalk.green('Dest'),
+      chalk.green('Distance'),
+      chalk.green('Human Req.'),
+      chalk.green('Expires'),
+      chalk.green('Pay'),
+      chalk.green('XP'),
+    ]);
+
+    matchingJobs.forEach((job) => {
+      const legs = getLegs(job);
+
+      jobTable.push([
+        job.MissionType.ShortName,
+        job.Description || null,
+        `${legs.length} legs`,
+        null,
+        null,
+        `${Math.round(job.TotalDistance)} mi`,
+        null,
+        getExpiresIn(job.ExpirationDate),
+        `${job.Pay}`,
+        `+${job.XP}`,
+      ]);
+
+      legs.forEach((leg) => {
+        jobTable.push([
+          null,
+          leg.Description,
+          null,
+          leg.CurrentAirport?.ICAO || null,
+          leg.DestinationAirport?.ICAO || null,
+          `${leg.Distance} mi`,
+          formatHumanOnly(leg),
+          null,
+          null,
+          null,
+        ]);
+      });
+    });
+
+    console.log(jobTable.toString());
+
+    if (index < companyFbos.length - 1) {
+      console.log('');
+    }
+  });
+};

--- a/src/loggers/logCompanyFboJobs.ts
+++ b/src/loggers/logCompanyFboJobs.ts
@@ -249,7 +249,7 @@ export const logCompanyFboJobs = (companyFboJobs: CompanyFboJobs[]): void => {
     console.log(chalk.whiteBright.bold(`${fbo.Airport.ICAO} - ${fbo.Name}`));
 
     if (!jobs.length) {
-      console.log(chalk.grey('No pending jobs.\n'));
+      console.log(chalk.grey('No matching jobs.\n'));
       return;
     }
 

--- a/src/loggers/logCompanyFboJobs.ts
+++ b/src/loggers/logCompanyFboJobs.ts
@@ -1,131 +1,258 @@
 import chalk from 'chalk';
-import { Airport, Cargo, Charter, Fbo, Job } from 'onair-api';
+import { Cargo, Charter, Fbo, Job } from 'onair-api';
 
 import { cliTable } from '../utils/cli-table';
 
-const getAirportIfMatchesBase = (airport: Airport | undefined, baseAirportId: string): Airport | undefined => {
-  return airport?.Id === baseAirportId ? airport : undefined;
+export interface CompanyFboJobs {
+  fbo: Fbo;
+  jobs: Job[];
+}
+
+type JobWithAirports = Job & {
+  BaseAirport?: { ICAO?: string };
+  MainAirport?: { ICAO?: string };
+  FBOLogisticQueryId?: string;
 };
 
-const getJobBaseAirport = (job: Job): Airport | undefined => {
-  let baseAirport: Airport | undefined = (job as Job & { BaseAirport?: Airport }).BaseAirport;
+interface RouteGroup {
+  current: string;
+  destination: string;
+  distance: number;
+  heading: number;
+  cargoWeight: number;
+  ecoPax: number;
+  businessPax: number;
+  firstPax: number;
+  descriptions: string[];
+  humanOnly: boolean;
+}
 
-  if (!baseAirport && job.Cargos.length > 0) {
-    job.Cargos.find((cargo) => {
-      baseAirport =
-        getAirportIfMatchesBase(cargo.DepartureAirport, job.BaseAirportId)
-        || getAirportIfMatchesBase(cargo.CurrentAirport, job.BaseAirportId)
-        || getAirportIfMatchesBase(cargo.DestinationAirport, job.BaseAirportId);
-
-      return Boolean(baseAirport);
-    });
-  }
-
-  if (!baseAirport && job.Charters.length > 0) {
-    job.Charters.find((charter) => {
-      baseAirport =
-        getAirportIfMatchesBase(charter.DepartureAirport, job.BaseAirportId)
-        || getAirportIfMatchesBase(charter.CurrentAirport, job.BaseAirportId)
-        || getAirportIfMatchesBase(charter.DestinationAirport, job.BaseAirportId);
-
-      return Boolean(baseAirport);
-    });
-  }
-
-  return baseAirport;
-};
+const PAX_WEIGHT = 190;
 
 const getExpiresIn = (dateStr: string): string => {
   const dueDate = new Date(dateStr).getTime();
+  if (Number.isNaN(dueDate)) {
+    return '-';
+  }
+
   const now = Date.now();
   const diffInMinutes = Math.round((dueDate - now) / 60000);
 
   if (diffInMinutes <= 0) {
-    return chalk.red(`${diffInMinutes} mins`);
+    return chalk.red(`${diffInMinutes}m`);
   }
 
   if (diffInMinutes <= 240) {
-    return chalk.yellow(`${diffInMinutes} mins`);
+    return chalk.yellow(`${diffInMinutes}m`);
   }
 
-  return chalk.green(`${diffInMinutes} mins`);
+  const diffInHours = Math.round(diffInMinutes / 60);
+  return chalk.green(`${diffInHours}h`);
 };
 
 const getLegs = (job: Job): Array<Cargo | Charter> => {
   return [...job.Cargos, ...job.Charters];
 };
 
-const formatHumanOnly = (leg: Cargo | Charter): string => {
-  return leg.HumanOnly ? 'Yes' : 'No';
+const formatNumber = (value: number): string => {
+  return Math.round(value).toLocaleString('en-GB');
 };
 
-export const logCompanyFboJobs = (companyFbos: Fbo[], companyJobs: Job[]): void => {
-  companyFbos.forEach((fbo, index) => {
-    const matchingJobs = companyJobs.filter((job) => {
-      if (job.BaseAirportId === fbo.AirportId) {
-        return true;
-      }
+const formatPay = (value: number): string => {
+  return Math.round(value).toLocaleString('en-GB');
+};
 
-      return getJobBaseAirport(job)?.Id === fbo.AirportId;
-    });
+const truncate = (value: string, maxLength: number): string => {
+  return value.length > maxLength ? `${value.slice(0, maxLength - 3)}...` : value;
+};
 
+const formatShortId = (id: string | undefined): string => {
+  return id ? id.slice(0, 5) : '-----';
+};
+
+const getPaxCount = (charter: Charter): number => {
+  return charter.PassengersNumber || 0;
+};
+
+const addPaxToGroup = (group: RouteGroup, charter: Charter): void => {
+  const paxCount = getPaxCount(charter);
+
+  switch (charter.MinPAXSeatConf) {
+    case 2:
+      group.firstPax += paxCount;
+      break;
+    case 1:
+      group.businessPax += paxCount;
+      break;
+    default:
+      group.ecoPax += paxCount;
+      break;
+  }
+};
+
+const getRouteKey = (leg: Cargo | Charter): string => {
+  return [
+    leg.CurrentAirport?.ICAO || '',
+    leg.DestinationAirport?.ICAO || '',
+    Math.round(leg.Heading || 0),
+    Math.round(leg.Distance || 0),
+  ].join('|');
+};
+
+const createRouteGroup = (leg: Cargo | Charter): RouteGroup => {
+  return {
+    current: leg.CurrentAirport?.ICAO || '',
+    destination: leg.DestinationAirport?.ICAO || '',
+    distance: leg.Distance || 0,
+    heading: leg.Heading || 0,
+    cargoWeight: 0,
+    ecoPax: 0,
+    businessPax: 0,
+    firstPax: 0,
+    descriptions: [],
+    humanOnly: false,
+  };
+};
+
+const getRouteGroups = (job: Job): RouteGroup[] => {
+  const routeGroups: Record<string, RouteGroup> = {};
+
+  getLegs(job).forEach((leg) => {
+    const routeKey = getRouteKey(leg);
+    const routeGroup = routeGroups[routeKey] || createRouteGroup(leg);
+
+    if ('Weight' in leg) {
+      routeGroup.cargoWeight += leg.Weight || 0;
+    } else {
+      addPaxToGroup(routeGroup, leg);
+    }
+
+    routeGroup.humanOnly = routeGroup.humanOnly || leg.HumanOnly;
+    if (leg.Description && !routeGroup.descriptions.includes(leg.Description)) {
+      routeGroup.descriptions.push(leg.Description);
+    }
+
+    routeGroups[routeKey] = routeGroup;
+  });
+
+  return Object.values(routeGroups);
+};
+
+const getTotalPax = (group: RouteGroup): number => {
+  return group.ecoPax + group.businessPax + group.firstPax;
+};
+
+const getTotalWeight = (group: RouteGroup): number => {
+  return group.cargoWeight + (getTotalPax(group) * PAX_WEIGHT);
+};
+
+const formatPax = (ecoPax: number, businessPax: number, firstPax: number): string => {
+  return `${ecoPax}/${businessPax}/${firstPax}`;
+};
+
+const formatRoutePax = (group: RouteGroup): string => {
+  const totalPax = getTotalPax(group);
+  return totalPax ? `${formatPax(group.ecoPax, group.businessPax, group.firstPax)} (${totalPax})` : '-';
+};
+
+const formatHeadDistance = (heading: number, distance: number): string => {
+  return `${Math.round(heading)}deg/${Math.round(distance)} NM`;
+};
+
+const getBaseAirportIcao = (job: JobWithAirports, fbo: Fbo): string => {
+  return job.BaseAirport?.ICAO || fbo.Airport?.ICAO || '';
+};
+
+const getMainAirportIcao = (job: JobWithAirports, routeGroups: RouteGroup[]): string => {
+  return job.MainAirport?.ICAO || routeGroups[0]?.destination || '';
+};
+
+const getPayloadDescription = (routeGroups: RouteGroup[]): string => {
+  return routeGroups
+    .flatMap((group) => group.descriptions)
+    .filter((description, index, descriptions) => descriptions.indexOf(description) === index)
+    .join(', ');
+};
+
+export const logCompanyFboJobs = (companyFboJobs: CompanyFboJobs[]): void => {
+  companyFboJobs.forEach(({ fbo, jobs }, index) => {
     console.log(chalk.whiteBright.bold(`${fbo.Airport.ICAO} - ${fbo.Name}`));
 
-    if (!matchingJobs.length) {
+    if (!jobs.length) {
       console.log(chalk.grey('No pending jobs.\n'));
       return;
     }
 
-    const jobTable = cliTable();
+    jobs.forEach((job) => {
+      const jobWithAirports = job as JobWithAirports;
+      const routeGroups = getRouteGroups(job);
+      const totalCargoWeight = routeGroups.reduce((total, group) => total + group.cargoWeight, 0);
+      const totalEcoPax = routeGroups.reduce((total, group) => total + group.ecoPax, 0);
+      const totalBusinessPax = routeGroups.reduce((total, group) => total + group.businessPax, 0);
+      const totalFirstPax = routeGroups.reduce((total, group) => total + group.firstPax, 0);
+      const totalWeight = routeGroups.reduce((total, group) => total + getTotalWeight(group), 0);
+      const summaryTable = cliTable();
 
-    jobTable.push([
-      chalk.green('Job Type'),
-      chalk.green('Description'),
-      chalk.green('Legs'),
-      chalk.green('Current'),
-      chalk.green('Dest'),
-      chalk.green('Distance'),
-      chalk.green('Human Req.'),
-      chalk.green('Expires'),
-      chalk.green('Pay'),
-      chalk.green('XP'),
-    ]);
-
-    matchingJobs.forEach((job) => {
-      const legs = getLegs(job);
-
-      jobTable.push([
-        job.MissionType.ShortName,
-        job.Description || null,
-        `${legs.length} legs`,
-        null,
-        null,
-        `${Math.round(job.TotalDistance)} mi`,
-        null,
-        getExpiresIn(job.ExpirationDate),
-        `${job.Pay}`,
-        `+${job.XP}`,
+      summaryTable.push([
+        chalk.green('Base'),
+        chalk.green('Main'),
+        chalk.green('Hd'),
+        chalk.green('Dist.'),
+        chalk.green('Cargo'),
+        chalk.green('Pax E/B/F'),
+        chalk.green('Payload'),
+        chalk.green('Total W.'),
+        chalk.green('Exp'),
+        chalk.green('Pay'),
       ]);
 
-      legs.forEach((leg) => {
-        jobTable.push([
-          null,
-          leg.Description,
-          null,
-          leg.CurrentAirport?.ICAO || null,
-          leg.DestinationAirport?.ICAO || null,
-          `${leg.Distance} mi`,
-          formatHumanOnly(leg),
-          null,
-          null,
-          null,
+      summaryTable.push([
+        getBaseAirportIcao(jobWithAirports, fbo),
+        getMainAirportIcao(jobWithAirports, routeGroups),
+        routeGroups[0] ? `${Math.round(routeGroups[0].heading)}deg` : '-',
+        routeGroups[0] ? formatNumber(routeGroups[0].distance) : '-',
+        formatNumber(totalCargoWeight),
+        formatPax(totalEcoPax, totalBusinessPax, totalFirstPax),
+        truncate(getPayloadDescription(routeGroups), 72),
+        formatNumber(totalWeight),
+        getExpiresIn(job.ExpirationDate),
+        formatPay(job.Pay),
+      ]);
+
+      console.log(summaryTable.toString());
+
+      const detailTable = cliTable();
+      detailTable.push([
+        chalk.green('Actions'),
+        chalk.green('Current'),
+        chalk.green('To'),
+        chalk.green(`Logistic Query (${formatShortId(jobWithAirports.Id)})`),
+        chalk.green('Cargo'),
+        chalk.green('Pax'),
+        chalk.green('Total W.'),
+        chalk.green('Head/Dist.'),
+        chalk.green('POIs'),
+      ]);
+
+      routeGroups.forEach((group) => {
+        detailTable.push([
+          'F',
+          group.current,
+          group.destination,
+          truncate(group.descriptions.join(', '), 72),
+          group.cargoWeight ? formatNumber(group.cargoWeight) : '-',
+          formatRoutePax(group),
+          formatNumber(getTotalWeight(group)),
+          formatHeadDistance(group.heading, group.distance),
+          '-',
         ]);
       });
+
+      console.log(detailTable.toString());
+      console.log('');
     });
 
-    console.log(jobTable.toString());
-
-    if (index < companyFbos.length - 1) {
+    if (index < companyFboJobs.length - 1) {
       console.log('');
     }
   });

--- a/src/loggers/logCompanyFbos.ts
+++ b/src/loggers/logCompanyFbos.ts
@@ -3,6 +3,10 @@ import { Fbo } from "onair-api";
 
 import { cliTable } from "../utils/cli-table";
 
+const formatWholeNumber = (value: number): string => {
+  return Math.trunc(value).toString();
+};
+
 export const logCompanyFbos = (companyFbos: Fbo[]): void => {
   const fboTable = cliTable();
 
@@ -23,9 +27,9 @@ export const logCompanyFbos = (companyFbos: Fbo[]): void => {
     fboTable.push([
       Fbo.Airport.ICAO,
       Fbo.Name,
-      Fbo.Fuel100LLQuantity + '/' + Fbo.Fuel100LLCapacity,
+      formatWholeNumber(Fbo.Fuel100LLQuantity) + '/' + formatWholeNumber(Fbo.Fuel100LLCapacity),
       Fbo.AllowFuel100LLSelling ? `✅ ${Fbo.Fuel100LLSellPrice}` : '❌',
-      Fbo.FuelJetQuantity + '/' + Fbo.FuelJetCapacity,
+      formatWholeNumber(Fbo.FuelJetQuantity) + '/' + formatWholeNumber(Fbo.FuelJetCapacity),
       Fbo.AllowFuelJetSelling ? `✅ ${Fbo.FuelJetSellPrice}` : '❌',
       Fbo.CargoWeightCapacity,
       Fbo.SleepingCapacity,

--- a/src/loggers/logCompanyIncome.ts
+++ b/src/loggers/logCompanyIncome.ts
@@ -1,9 +1,9 @@
 import chalk from "chalk";
-import { IncomeStatement, ISAccount } from "onair-api";
+import { IncomeStatement, Account } from "onair-api";
 
 const log = console.log;
 
-const logAccounts = (account: ISAccount[], cols: number): void => {
+const logAccounts = (account: Account[], cols: number): void => {
   account.forEach((ISAccount) => {
     const amount = ISAccount.Amount.toLocaleString('en-GB');
     const paddingCount = cols - ISAccount.Name.length - amount.length;

--- a/src/loggers/logCompanyIncome.ts
+++ b/src/loggers/logCompanyIncome.ts
@@ -7,7 +7,7 @@ const logAccounts = (account: ISAccount[], cols: number): void => {
   account.forEach((ISAccount) => {
     const amount = ISAccount.Amount.toLocaleString('en-GB');
     const paddingCount = cols - ISAccount.Name.length - amount.length;
-    log(ISAccount.Name + ' '.repeat(paddingCount) + amount);
+    log(ISAccount.Name + chalk.gray('.'.repeat(paddingCount)) + amount);
   });
 }
 

--- a/src/loggers/logCompanyIncome.ts
+++ b/src/loggers/logCompanyIncome.ts
@@ -1,0 +1,48 @@
+import chalk from "chalk";
+import { IncomeStatement, ISAccount } from "onair-api";
+
+const log = console.log;
+
+const logAccounts = (account: ISAccount[], cols: number): void => {
+  account.forEach((ISAccount) => {
+    const amount = ISAccount.Amount.toLocaleString('en-GB');
+    const paddingCount = cols - ISAccount.Name.length - amount.length;
+    log(ISAccount.Name + ' '.repeat(paddingCount) + amount);
+  });
+}
+
+export const logCompanyIncome = (income: IncomeStatement, daysToDisplay: number, cols:number = 80): void => {
+  
+
+  const lengthLabel = daysToDisplay > 1 ? daysToDisplay + ' days' : 'day';
+
+  log(chalk.greenBright.bold(`Your income statement summary for the last ${lengthLabel}\n`));
+
+  const revLabel = 'Revenues';
+  const revAmountLabel = income.REVAmount.toLocaleString('en-GB') + ' 💰';
+  const revPaddingCount = cols - revLabel.length - revAmountLabel.length;
+
+  log(chalk.cyanBright(revLabel) + ' '.repeat(revPaddingCount) + revAmountLabel + '\n');
+
+  const headersPaddingCount = cols - 'Name'.length - 'Amount'.length;
+
+  log(chalk.green('Name') + ' '.repeat(headersPaddingCount) + chalk.green('Amount'));
+
+  logAccounts(income.REVAccounts, cols);
+
+  const expLabel = 'Expenses';
+  const expAmountLabel = income.EXPAmount.toLocaleString('en-GB') + ' 💰';
+  const expPaddingCount = cols - expLabel.length - expAmountLabel.length;
+
+  log('\n' + chalk.cyanBright(expLabel) + ' '.repeat(expPaddingCount) + expAmountLabel + '\n');
+
+  log(chalk.green('Name') + ' '.repeat(headersPaddingCount) + chalk.green('Amount'));
+
+  logAccounts(income.EXPAccounts, cols);
+
+  const netIncomeLabel = 'Net income for the period';
+  const netIncomeAmountLabel = income.NetIncomeAmount.toLocaleString('en-GB') + ' 💰';
+  const netIncomePaddingCount = cols - netIncomeLabel.length - netIncomeAmountLabel.length;
+
+  log('\n' + chalk.cyanBright(netIncomeLabel) + ' '.repeat(netIncomePaddingCount) + netIncomeAmountLabel);
+}

--- a/src/loggers/logCompanyJobs.ts
+++ b/src/loggers/logCompanyJobs.ts
@@ -6,6 +6,10 @@ import { cliTable } from "../utils/cli-table";
 export const logCompanyJobs = (companyJobs: Job[]): void => {
   const jobTable = cliTable();
 
+  const getAirportIfMatchesBase = (airport: Airport | undefined, baseAirportId: string) => {
+    return airport?.Id === baseAirportId ? airport : undefined;
+  };
+
   jobTable.push([
     chalk.green('Job Type'),
     chalk.green('Description'),
@@ -41,30 +45,28 @@ export const logCompanyJobs = (companyJobs: Job[]): void => {
 
   companyJobs.forEach((job) => {
     // determine BaseAirport by matching BaseAirportId up within cargo or charter arrays
-    let baseAirport: Airport | undefined;
+    let baseAirport: Airport | undefined = (job as Job & { BaseAirport?: Airport }).BaseAirport;
 
-    if (job.Cargos.length > 0) {
+    if (!baseAirport && job.Cargos.length > 0) {
       // iterate over Cargos array and find baseAirport
       job.Cargos.find((e) => {
-          if (e.DepartureAirport.Id === job.BaseAirportId) {
-              baseAirport = e.DepartureAirport
-          } else if (e.CurrentAirport.Id === job.BaseAirportId) {
-              baseAirport = e.CurrentAirport
-          }else if (e.DestinationAirport.Id === job.BaseAirportId) {
-              baseAirport = e.DestinationAirport
-          }
+          baseAirport =
+            getAirportIfMatchesBase(e.DepartureAirport, job.BaseAirportId)
+            || getAirportIfMatchesBase(e.CurrentAirport, job.BaseAirportId)
+            || getAirportIfMatchesBase(e.DestinationAirport, job.BaseAirportId);
+
+          return Boolean(baseAirport);
       })
     }
 
-    if (job.Charters.length > 0) {
+    if (!baseAirport && job.Charters.length > 0) {
         job.Charters.find((e) => {
-          if (e.DepartureAirport.Id === job.BaseAirportId) {
-            baseAirport = e.DepartureAirport
-        } else if (e.CurrentAirport.Id === job.BaseAirportId) {
-            baseAirport = e.CurrentAirport
-        }else if (e.DestinationAirport.Id === job.BaseAirportId) {
-            baseAirport = e.DestinationAirport
-        }
+          baseAirport =
+            getAirportIfMatchesBase(e.DepartureAirport, job.BaseAirportId)
+            || getAirportIfMatchesBase(e.CurrentAirport, job.BaseAirportId)
+            || getAirportIfMatchesBase(e.DestinationAirport, job.BaseAirportId);
+
+          return Boolean(baseAirport);
       })
     }
 

--- a/src/loggers/logCompanyNotifications.ts
+++ b/src/loggers/logCompanyNotifications.ts
@@ -1,0 +1,45 @@
+import chalk from "chalk";
+
+import { CompanyNotification } from "../api/getCompanyNotifications";
+import { cliTable } from "../utils/cli-table";
+
+const formatDate = (dateStr: string): string => {
+  const date = new Date(Date.parse(dateStr));
+
+  return Number.isNaN(date.getTime()) ? dateStr : date.toLocaleString('en-GB');
+};
+
+const formatAmount = (amount: number): string => {
+  if (amount === 0) {
+    return '-';
+  }
+
+  const formattedAmount = amount.toLocaleString('en-GB');
+  return amount < 0 ? chalk.red(formattedAmount) : chalk.green(formattedAmount);
+};
+
+export const logCompanyNotifications = (notifications: CompanyNotification[]): void => {
+  const notificationTable = cliTable();
+
+  notificationTable.push([
+    chalk.green('Date'),
+    chalk.green('Read'),
+    chalk.green('Category'),
+    chalk.green('Action'),
+    chalk.green('Amount'),
+    chalk.green('Description'),
+  ]);
+
+  notifications.forEach((notification) => {
+    notificationTable.push([
+      formatDate(notification.ZuluEventTime),
+      notification.IsRead ? 'Yes' : 'No',
+      notification.Category,
+      notification.Action,
+      formatAmount(notification.Amount),
+      notification.Description,
+    ]);
+  });
+
+  console.log(notificationTable.toString());
+};

--- a/src/loggers/logCompanyTradingGoods.ts
+++ b/src/loggers/logCompanyTradingGoods.ts
@@ -3,11 +3,57 @@ import chalk from 'chalk';
 import { CompanyTradingGood } from '../api/getCompanyTradingGoods';
 import { cliTable } from '../utils/cli-table';
 
+const isIdKey = (key: string) => key.endsWith('Id');
+
+const getReadableObjectValue = (value: unknown): string | undefined => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+
+  if (typeof record['DisplayName'] === 'string') {
+    return `${record['DisplayName']}`;
+  }
+
+  if (typeof record['Identifier'] === 'string') {
+    return `${record['Identifier']}`;
+  }
+
+  if (typeof record['Name'] === 'string') {
+    return `${record['Name']}`;
+  }
+
+  if (typeof record['ICAO'] === 'string') {
+    return `${record['ICAO']}`;
+  }
+
+  if (typeof record['AirlineCode'] === 'string') {
+    return `${record['AirlineCode']}`;
+  }
+
+  return undefined;
+};
+
+const hasReadableIdReplacement = (items: CompanyTradingGood[], key: string) => {
+  const relatedObjectKey = key.slice(0, -2);
+
+  return items.some((item) => Boolean(getReadableObjectValue(item[relatedObjectKey])));
+};
+
 const formatHeading = (key: string): string => {
   return key
     .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
     .replace(/_/g, ' ')
     .replace(/\b\w/g, (char) => char.toUpperCase());
+};
+
+const getColumnHeading = (key: string, readableIds = false) => {
+  if (readableIds && isIdKey(key)) {
+    return formatHeading(key.slice(0, -2));
+  }
+
+  return formatHeading(key);
 };
 
 const formatValue = (value: unknown): string => {
@@ -48,19 +94,63 @@ const formatValue = (value: unknown): string => {
   return `${value}`;
 };
 
-export const logCompanyTradingGoods = (companyTradingGoods: CompanyTradingGood[]): void => {
-  const keys = Array.from(
+const getTradingGoodsKeys = (
+  companyTradingGoods: CompanyTradingGood[],
+  hideIds = false,
+  readableIds = false
+) => {
+  const allKeys = Array.from(
     companyTradingGoods.reduce((acc, item) => {
       Object.keys(item).forEach((key) => acc.add(key));
       return acc;
     }, new Set<string>())
   );
 
+  return allKeys.filter((key) => {
+    if (hideIds && isIdKey(key)) {
+      return false;
+    }
+
+    if (readableIds && isIdKey(key) && !hasReadableIdReplacement(companyTradingGoods, key)) {
+      return false;
+    }
+
+    if (readableIds && !hideIds && !isIdKey(key)) {
+      const relatedIdKey = `${key}Id`;
+      if (allKeys.includes(relatedIdKey)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+};
+
+const getColumnValue = (good: CompanyTradingGood, key: string, readableIds = false) => {
+  if (readableIds && isIdKey(key)) {
+    const relatedObjectKey = key.slice(0, -2);
+    const readableValue = getReadableObjectValue(good[relatedObjectKey]);
+
+    if (readableValue) {
+      return readableValue;
+    }
+  }
+
+  return formatValue(good[key]);
+};
+
+export const logCompanyTradingGoods = (
+  companyTradingGoods: CompanyTradingGood[],
+  hideIds = false,
+  readableIds = false
+): void => {
+  const keys = getTradingGoodsKeys(companyTradingGoods, hideIds, readableIds);
+
   const tradingGoodsTable = cliTable();
-  tradingGoodsTable.push(keys.map((key) => chalk.green(formatHeading(key))));
+  tradingGoodsTable.push(keys.map((key) => chalk.green(getColumnHeading(key, readableIds))));
 
   companyTradingGoods.forEach((good) => {
-    tradingGoodsTable.push(keys.map((key) => formatValue(good[key])));
+    tradingGoodsTable.push(keys.map((key) => getColumnValue(good, key, readableIds)));
   });
 
   console.log(tradingGoodsTable.toString());

--- a/src/loggers/logCompanyTradingGoods.ts
+++ b/src/loggers/logCompanyTradingGoods.ts
@@ -1,0 +1,67 @@
+import chalk from 'chalk';
+
+import { CompanyTradingGood } from '../api/getCompanyTradingGoods';
+import { cliTable } from '../utils/cli-table';
+
+const formatHeading = (key: string): string => {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+};
+
+const formatValue = (value: unknown): string => {
+  if (value === null || typeof value === 'undefined') {
+    return '';
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return `${value}`;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => formatValue(entry)).join(', ');
+  }
+
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+
+    if (typeof record['DisplayName'] === 'string') {
+      return `${record['DisplayName']}`;
+    }
+
+    if (typeof record['Name'] === 'string') {
+      return `${record['Name']}`;
+    }
+
+    if (typeof record['ICAO'] === 'string') {
+      return `${record['ICAO']}`;
+    }
+
+    if (typeof record['Id'] === 'string') {
+      return `${record['Id']}`;
+    }
+
+    return JSON.stringify(value);
+  }
+
+  return `${value}`;
+};
+
+export const logCompanyTradingGoods = (companyTradingGoods: CompanyTradingGood[]): void => {
+  const keys = Array.from(
+    companyTradingGoods.reduce((acc, item) => {
+      Object.keys(item).forEach((key) => acc.add(key));
+      return acc;
+    }, new Set<string>())
+  );
+
+  const tradingGoodsTable = cliTable();
+  tradingGoodsTable.push(keys.map((key) => chalk.green(formatHeading(key))));
+
+  companyTradingGoods.forEach((good) => {
+    tradingGoodsTable.push(keys.map((key) => formatValue(good[key])));
+  });
+
+  console.log(tradingGoodsTable.toString());
+};

--- a/src/loggers/logCompanyTradingGoods.ts
+++ b/src/loggers/logCompanyTradingGoods.ts
@@ -127,6 +127,10 @@ const getTradingGoodsKeys = (
 };
 
 const getColumnValue = (good: CompanyTradingGood, key: string, readableIds = false) => {
+  if (key === 'InTransit') {
+    return Boolean(good['CurrentAircraftId'] || good['CurrentAircraft']) ? 'Yes' : 'No';
+  }
+
   if (readableIds && isIdKey(key)) {
     const relatedObjectKey = key.slice(0, -2);
     const readableValue = getReadableObjectValue(good[relatedObjectKey]);
@@ -139,12 +143,78 @@ const getColumnValue = (good: CompanyTradingGood, key: string, readableIds = fal
   return formatValue(good[key]);
 };
 
+const getLocationLabel = (good: CompanyTradingGood) => {
+  const currentAirport = getReadableObjectValue(good['CurrentAirport']);
+  const currentAircraft = getReadableObjectValue(good['CurrentAircraft']);
+
+  if (currentAirport) {
+    return currentAirport;
+  }
+
+  if (currentAircraft) {
+    return `Aircraft ${currentAircraft}`;
+  }
+
+  return '-';
+};
+
+export const logCompanyTradingGoodsSummary = (companyTradingGoods: CompanyTradingGood[]): void => {
+  const groupedTradingGoods = Array.from(
+    companyTradingGoods.reduce((acc, good) => {
+      const merchandiseType = getReadableObjectValue(good['MerchandiseType']) || '-';
+      const inTransit = Boolean(good['CurrentAircraftId'] || good['CurrentAircraft']) ? 'In Transit' : 'On Site';
+      const location = getLocationLabel(good);
+      const groupKey = `${location}__${merchandiseType}__${inTransit}`;
+      const quantity = Number(good['Quantity']) || 0;
+      const pricePerUnit = formatValue(good['PricePerUnit']) || '0';
+
+      if (!acc.has(groupKey)) {
+        acc.set(groupKey, {
+          location,
+          merchandiseType,
+          inTransit,
+          quantity: 0,
+          prices: new Set<string>(),
+        });
+      }
+
+      const existingGroup = acc.get(groupKey)!;
+      existingGroup.quantity += quantity;
+      existingGroup.prices.add(pricePerUnit);
+
+      return acc;
+    }, new Map<string, {
+      location: string;
+      merchandiseType: string;
+      inTransit: string;
+      quantity: number;
+      prices: Set<string>;
+    }>())
+  ).map(([, group]) => group);
+
+  const quantityWidth = groupedTradingGoods.reduce((maxWidth, group) => {
+    return Math.max(maxWidth, `${group.quantity}`.length);
+  }, 1);
+  const locationWidth = groupedTradingGoods.reduce((maxWidth, group) => {
+    return Math.max(maxWidth, group.location.length);
+  }, 1);
+
+  groupedTradingGoods.forEach((group) => {
+    const location = group.location.padEnd(locationWidth, ' ');
+    const quantity = `${group.quantity}`.padStart(quantityWidth, '0');
+    const prices = Array.from(group.prices);
+    const priceLabel = prices.length === 1 ? prices[0] : prices.join('/');
+
+    console.log(`${location} | ${quantity} | ${group.merchandiseType} | ${group.inTransit} | Price ${priceLabel}`);
+  });
+};
+
 export const logCompanyTradingGoods = (
   companyTradingGoods: CompanyTradingGood[],
   hideIds = false,
   readableIds = false
 ): void => {
-  const keys = getTradingGoodsKeys(companyTradingGoods, hideIds, readableIds);
+  const keys = ['InTransit', ...getTradingGoodsKeys(companyTradingGoods, hideIds, readableIds)];
 
   const tradingGoodsTable = cliTable();
   tradingGoodsTable.push(keys.map((key) => chalk.green(getColumnHeading(key, readableIds))));

--- a/src/loggers/logCompanyWorkOrders.ts
+++ b/src/loggers/logCompanyWorkOrders.ts
@@ -119,6 +119,27 @@ export const getWorkOrderStatus = (workOrder: CompanyWorkOrder) => {
   ]) || 'UNKNOWN';
 };
 
+export const WORK_ORDER_STATUS_FILTERS = [
+  'inactive',
+  'pending',
+  'in-progress',
+  'finished',
+  'failed',
+  'waiting',
+] as const;
+
+const normalizeWorkOrderStatus = (status: string): string => {
+  return status.trim().toLocaleLowerCase().replace(/\s+/g, '-');
+};
+
+export const matchesWorkOrderStatus = (
+  workOrder: CompanyWorkOrder,
+  statusFilter?: string
+): boolean => {
+  return !statusFilter
+    || normalizeWorkOrderStatus(getWorkOrderStatus(workOrder)) === normalizeWorkOrderStatus(statusFilter);
+};
+
 const getWorkOrderSummary = (workOrder: CompanyWorkOrder) => {
   return pickFirstString([
     workOrder.Description,

--- a/src/loggers/logCompanyWorkOrders.ts
+++ b/src/loggers/logCompanyWorkOrders.ts
@@ -1,0 +1,221 @@
+import chalk from 'chalk';
+
+import { CompanyWorkOrder } from '../types/CompanyWorkOrder';
+import { cliTable } from '../utils/cli-table';
+
+const toRecord = (value: unknown): Record<string, unknown> | undefined => {
+  return typeof value === 'object' && value !== null ? value as Record<string, unknown> : undefined;
+};
+
+const toStringValue = (value: unknown): string | undefined => {
+  return typeof value === 'string' && value.trim().length ? value : undefined;
+};
+
+const toNumberValue = (value: unknown): number | undefined => {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+};
+
+const pickFirstString = (values: unknown[]): string | undefined => {
+  for (const value of values) {
+    const str = toStringValue(value);
+    if (str) {
+      return str;
+    }
+  }
+
+  return undefined;
+};
+
+const getAircraftRecord = (workOrder: CompanyWorkOrder) => toRecord(workOrder.Aircraft);
+const getAircraftTypeRecord = (workOrder: CompanyWorkOrder) => {
+  const aircraftRecord = getAircraftRecord(workOrder);
+  return toRecord(aircraftRecord?.AircraftType) || toRecord(workOrder.AircraftType);
+};
+
+export const getWorkOrderAircraftDisplayName = (workOrder: CompanyWorkOrder) => {
+  const aircraftType = getAircraftTypeRecord(workOrder);
+
+  return pickFirstString([
+    workOrder.AircraftDisplayName,
+    aircraftType?.DisplayName,
+    workOrder.AircraftName,
+  ]);
+};
+
+export const getWorkOrderAircraftIcao = (workOrder: CompanyWorkOrder) => {
+  const aircraftType = getAircraftTypeRecord(workOrder);
+
+  return pickFirstString([
+    workOrder.AircraftIcao,
+    workOrder.AircraftICAO,
+    aircraftType?.ICAO,
+    aircraftType?.Icao,
+    aircraftType?.IcaoCode,
+  ]);
+};
+
+const getWorkOrderAircraftIdentifier = (workOrder: CompanyWorkOrder) => {
+  const aircraft = getAircraftRecord(workOrder);
+
+  return pickFirstString([
+    workOrder.AircraftIdentifier,
+    aircraft?.Identifier,
+  ]);
+};
+
+const getWorkOrderStatus = (workOrder: CompanyWorkOrder) => {
+  const numericStatus = toNumberValue(workOrder.Status);
+
+  if (typeof numericStatus !== 'undefined') {
+    const mappedStatus = ({
+      0: 'Inactive',
+      1: 'Pending',
+      2: 'Finished',
+      3: 'Failed',
+      4: 'Waiting',
+    } as Record<number, string>)[numericStatus];
+
+    return mappedStatus || `UNKNOWN (${numericStatus})`;
+  }
+
+  return pickFirstString([
+    workOrder.CurrentStatus,
+    workOrder.WorkOrderStatus,
+    workOrder.State,
+  ]) || 'UNKNOWN';
+};
+
+const getWorkOrderSummary = (workOrder: CompanyWorkOrder) => {
+  return pickFirstString([
+    workOrder.Description,
+    workOrder.Name,
+    workOrder.Title,
+    workOrder.Category,
+  ]);
+};
+
+const toArray = (value: unknown): unknown[] => {
+  return Array.isArray(value) ? value : [];
+};
+
+const getCrewDisplayName = (value: unknown): string | undefined => {
+  if (typeof value === 'string' && value.trim().length) {
+    return value;
+  }
+
+  const record = toRecord(value);
+
+  if (!record) {
+    return undefined;
+  }
+
+  const nestedEmployee = toRecord(record.Employee)
+    || toRecord(record.CrewMember)
+    || toRecord(record.Person)
+    || toRecord(record.People);
+  const firstName = pickFirstString([record.FirstName, nestedEmployee?.FirstName]);
+  const lastName = pickFirstString([record.LastName, nestedEmployee?.LastName]);
+  const combinedName = [firstName, lastName].filter((part): part is string => Boolean(part)).join(' ');
+
+  if (combinedName) {
+    return combinedName;
+  }
+
+  return pickFirstString([
+    record.DisplayName,
+    record.Name,
+    record.Nickname,
+    record.Pseudo,
+    record.InitialPseudo,
+    nestedEmployee?.DisplayName,
+    nestedEmployee?.Name,
+    nestedEmployee?.Nickname,
+    nestedEmployee?.Pseudo,
+    nestedEmployee?.InitialPseudo,
+  ]);
+};
+
+const getCrewRoleName = (value: unknown) => {
+  const record = toRecord(value);
+  const role = toNumberValue(record?.Role);
+
+  if (typeof role === 'undefined') {
+    return undefined;
+  }
+
+  return ({
+    0: 'Pilot',
+    1: 'Copilot',
+    2: 'Cabin Crew',
+  } as Record<number, string>)[role] || `Role ${role}`;
+};
+
+export const getWorkOrderAssignedCrew = (workOrder: CompanyWorkOrder) => {
+  const crewValues = [
+    ...toArray(workOrder.AssignedCrew),
+    ...toArray(workOrder.AssignedCrews),
+    ...toArray(workOrder.Crew),
+    ...toArray(workOrder.Crews),
+    ...toArray(workOrder.Employees),
+  ];
+
+  const crewNames = crewValues
+    .map((crewValue) => {
+      const crewName = getCrewDisplayName(crewValue);
+      if (!crewName) {
+        return undefined;
+      }
+
+      const crewRole = getCrewRoleName(crewValue);
+      return crewRole ? `${crewName} (${crewRole})` : crewName;
+    })
+    .filter((name): name is string => Boolean(name));
+
+  return crewNames.length ? crewNames.join(' / ') : undefined;
+};
+
+export const logCompanyWorkOrders = (
+  workOrders: CompanyWorkOrder[],
+  showCrewAssigned = false,
+  showWorkOrderId = false
+) => {
+  const workOrderTable = cliTable();
+
+  const headerRow = [
+    chalk.green('Aircraft'),
+    chalk.green('Ident'),
+    chalk.green('Status'),
+    chalk.green('Summary'),
+  ];
+
+  if (showCrewAssigned) {
+    headerRow.push(chalk.green('Crew Assigned'));
+  }
+
+  if (showWorkOrderId) {
+    headerRow.push(chalk.green('Work Order ID'));
+  }
+
+  workOrderTable.push(headerRow);
+
+  workOrders.forEach((workOrder) => {
+    const row = [
+      getWorkOrderAircraftDisplayName(workOrder) || '-',
+      getWorkOrderAircraftIdentifier(workOrder) || '-',
+      getWorkOrderStatus(workOrder) || '-',
+      getWorkOrderSummary(workOrder) || '-',
+    ];
+
+    if (showCrewAssigned) {
+      row.push(getWorkOrderAssignedCrew(workOrder) || '-');
+    }
+
+    if (showWorkOrderId) {
+      row.push(workOrder.Id || '-');
+    }
+
+    workOrderTable.push(row);
+  });
+
+  console.log(workOrderTable.toString());
+};

--- a/src/loggers/logCompanyWorkOrders.ts
+++ b/src/loggers/logCompanyWorkOrders.ts
@@ -63,10 +63,43 @@ const getWorkOrderAircraftIdentifier = (workOrder: CompanyWorkOrder) => {
   ]);
 };
 
+const toArray = (value: unknown): unknown[] => {
+  return Array.isArray(value) ? value : [];
+};
+
+const hasActiveAction = (workOrder: CompanyWorkOrder) => {
+  const actions = toArray(workOrder.Actions);
+
+  return actions.some((actionValue) => {
+    const action = toRecord(actionValue);
+    const actionStatus = toNumberValue(action?.Status);
+
+    return Boolean(
+      action?.StartedTime
+      || action?.FlightId
+      || action?.CurrentFlightId
+      || actionStatus === 1
+    );
+  });
+};
+
 const getWorkOrderStatus = (workOrder: CompanyWorkOrder) => {
   const numericStatus = toNumberValue(workOrder.Status);
+  const aircraft = getAircraftRecord(workOrder);
+  const aircraftStatus = toNumberValue(aircraft?.AircraftStatus);
 
   if (typeof numericStatus !== 'undefined') {
+    if (
+      numericStatus === 1
+      && (
+        hasActiveAction(workOrder)
+        || workOrder.IsTicking === true
+        || aircraftStatus === 3
+      )
+    ) {
+      return 'In Progress';
+    }
+
     const mappedStatus = ({
       0: 'Inactive',
       1: 'Pending',
@@ -92,10 +125,6 @@ const getWorkOrderSummary = (workOrder: CompanyWorkOrder) => {
     workOrder.Title,
     workOrder.Category,
   ]);
-};
-
-const toArray = (value: unknown): unknown[] => {
-  return Array.isArray(value) ? value : [];
 };
 
 const getCrewDisplayName = (value: unknown): string | undefined => {

--- a/src/loggers/logCompanyWorkOrders.ts
+++ b/src/loggers/logCompanyWorkOrders.ts
@@ -54,7 +54,7 @@ export const getWorkOrderAircraftIcao = (workOrder: CompanyWorkOrder) => {
   ]);
 };
 
-const getWorkOrderAircraftIdentifier = (workOrder: CompanyWorkOrder) => {
+export const getWorkOrderAircraftIdentifier = (workOrder: CompanyWorkOrder) => {
   const aircraft = getAircraftRecord(workOrder);
 
   return pickFirstString([

--- a/src/loggers/logCompanyWorkOrders.ts
+++ b/src/loggers/logCompanyWorkOrders.ts
@@ -74,19 +74,21 @@ const hasActiveAction = (workOrder: CompanyWorkOrder) => {
     const action = toRecord(actionValue);
     const actionStatus = toNumberValue(action?.Status);
 
-    return Boolean(
+    if (typeof actionStatus !== 'undefined') {
+      return actionStatus === 1;
+    }
+
+    const hasFinished = Boolean(action?.EndedTime || action?.FailedTime);
+    return !hasFinished && Boolean(
       action?.StartedTime
       || action?.FlightId
       || action?.CurrentFlightId
-      || actionStatus === 1
     );
   });
 };
 
-const getWorkOrderStatus = (workOrder: CompanyWorkOrder) => {
+export const getWorkOrderStatus = (workOrder: CompanyWorkOrder) => {
   const numericStatus = toNumberValue(workOrder.Status);
-  const aircraft = getAircraftRecord(workOrder);
-  const aircraftStatus = toNumberValue(aircraft?.AircraftStatus);
 
   if (typeof numericStatus !== 'undefined') {
     if (
@@ -94,7 +96,6 @@ const getWorkOrderStatus = (workOrder: CompanyWorkOrder) => {
       && (
         hasActiveAction(workOrder)
         || workOrder.IsTicking === true
-        || aircraftStatus === 3
       )
     ) {
       return 'In Progress';

--- a/src/loggers/logCompanyWorkOrders.ts
+++ b/src/loggers/logCompanyWorkOrders.ts
@@ -179,6 +179,109 @@ const getCrewRoleName = (value: unknown) => {
   } as Record<number, string>)[role] || `Role ${role}`;
 };
 
+const formatDateValue = (value: unknown): string | undefined => {
+  const dateString = toStringValue(value);
+
+  if (!dateString) {
+    return undefined;
+  }
+
+  const date = new Date(dateString);
+  return Number.isNaN(date.getTime()) ? dateString : date.toLocaleString('en-GB');
+};
+
+const formatNumberValue = (value: unknown, suffix = ''): string | undefined => {
+  const number = toNumberValue(value);
+  return typeof number === 'undefined' ? undefined : `${number.toLocaleString('en-GB')}${suffix}`;
+};
+
+const getAirportDisplay = (value: unknown, fallbackId: unknown): string | undefined => {
+  const airport = toRecord(value);
+
+  return pickFirstString([
+    airport?.ICAO,
+    airport?.Icao,
+    airport?.Name,
+    fallbackId,
+  ]);
+};
+
+const getActionStatus = (action: Record<string, unknown>): string | undefined => {
+  const displayStatus = pickFirstString([action.StatusDisplay, action.CurrentStatus, action.State]);
+
+  if (displayStatus) {
+    return displayStatus;
+  }
+
+  const status = toNumberValue(action.Status);
+
+  if (typeof status === 'undefined') {
+    return undefined;
+  }
+
+  return ({
+    0: 'Pending',
+    1: 'In Progress',
+    2: 'Finished',
+    3: 'Failed',
+  } as Record<number, string>)[status] || `UNKNOWN (${status})`;
+};
+
+const getActionStep = (action: Record<string, unknown>): string | undefined => {
+  const step = toNumberValue(action.Step);
+  return typeof step === 'undefined' ? undefined : `Step ${step}`;
+};
+
+const getActionLoadDisplay = (value: unknown): string | undefined => {
+  const load = toRecord(value);
+
+  if (!load) {
+    return undefined;
+  }
+
+  const cargo = toRecord(load.Cargo);
+  const charter = toRecord(load.Charter);
+  const description = pickFirstString([
+    cargo?.Description,
+    charter?.Description,
+    load.CargoId,
+    load.CharterId,
+  ]);
+  const cargoWeight = formatNumberValue(load.CargoWeight, ' lb');
+  const passengerCount = formatNumberValue(load.PassengerNumber, ' PAX');
+  const required = load.Required === true ? 'required' : undefined;
+  const parts = [description, cargoWeight, passengerCount, required]
+    .filter((part): part is string => typeof part === 'string');
+
+  return parts.length ? parts.join(', ') : undefined;
+};
+
+const getActionPassengerDisplay = (value: unknown): string | undefined => {
+  const passenger = toRecord(value);
+
+  if (!passenger) {
+    return undefined;
+  }
+
+  return getCrewDisplayName(passenger.People) || pickFirstString([passenger.PeopleId]);
+};
+
+const getActionFlags = (action: Record<string, unknown>): string | undefined => {
+  const flags = [
+    action.DontLoadFuel === true ? 'Do not load fuel' : undefined,
+    action.WaitingForCargoPAX === true ? 'Waiting for cargo/PAX' : undefined,
+    action.FinishedAtAlternate === true ? 'Finished at alternate' : undefined,
+    action.ForceCrewToRestAtEnd === true ? 'Crew rests at end' : undefined,
+  ].filter((flag): flag is string => typeof flag === 'string');
+
+  return flags.length ? flags.join(' / ') : undefined;
+};
+
+const pushDetailRow = (table: ReturnType<typeof cliTable>, label: string, value: unknown) => {
+  const displayValue = typeof value === 'string' && value.length ? value : '-';
+  table.push([chalk.green(label), displayValue]);
+};
+
 export const getWorkOrderAssignedCrew = (workOrder: CompanyWorkOrder) => {
   const crewValues = [
     ...toArray(workOrder.AssignedCrew),
@@ -247,4 +350,80 @@ export const logCompanyWorkOrders = (
   });
 
   console.log(workOrderTable.toString());
+};
+
+export const logCompanyWorkOrderDetails = (workOrder: CompanyWorkOrder) => {
+  console.log(chalk.greenBright.bold('Work order details\n'));
+
+  const detailsTable = cliTable();
+  pushDetailRow(detailsTable, 'Work Order ID', workOrder.Id);
+  pushDetailRow(detailsTable, 'Aircraft', getWorkOrderAircraftDisplayName(workOrder));
+  pushDetailRow(detailsTable, 'Ident', getWorkOrderAircraftIdentifier(workOrder));
+  pushDetailRow(detailsTable, 'Aircraft ICAO', getWorkOrderAircraftIcao(workOrder));
+  pushDetailRow(detailsTable, 'Status', getWorkOrderStatus(workOrder));
+  pushDetailRow(detailsTable, 'Summary', getWorkOrderSummary(workOrder));
+  pushDetailRow(detailsTable, 'Start Date', formatDateValue(workOrder.StartDate));
+  pushDetailRow(
+    detailsTable,
+    'Departure Airport',
+    getAirportDisplay(workOrder.DepartureAirport, workOrder.DepartureAirportId)
+  );
+  pushDetailRow(detailsTable, 'Crew Assigned', getWorkOrderAssignedCrew(workOrder));
+  pushDetailRow(detailsTable, 'Processing', workOrder.IsTicking === true ? 'Active' : 'Inactive');
+  console.log(detailsTable.toString());
+
+  const actions = toArray(workOrder.Actions);
+
+  if (!actions.length) {
+    console.log('\nNo actions found for this work order.');
+    return;
+  }
+
+  actions.forEach((actionValue, index) => {
+    const action = toRecord(actionValue);
+
+    if (!action) {
+      return;
+    }
+
+    const actionNumber = index + 1;
+    const actionName = pickFirstString([action.Name]) || `Action ${actionNumber}`;
+    console.log(chalk.whiteBright.bold(`\n${actionNumber}. ${actionName}`));
+
+    const actionTable = cliTable();
+    pushDetailRow(actionTable, 'Action ID', pickFirstString([action.Id]));
+    pushDetailRow(actionTable, 'Status', getActionStatus(action));
+    pushDetailRow(actionTable, 'Step', getActionStep(action));
+    pushDetailRow(
+      actionTable,
+      'Destination',
+      getAirportDisplay(action.FlyDestinationAirport, action.FlyDestinationAirportId)
+    );
+    pushDetailRow(
+      actionTable,
+      'Alternate',
+      getAirportDisplay(action.FlyAlternateAirport, action.FlyAlternateAirportId)
+    );
+    pushDetailRow(actionTable, 'Flight ID', pickFirstString([action.FlightId, action.CurrentFlightId]));
+    pushDetailRow(actionTable, 'Fuel to Load', formatNumberValue(action.FuelToLoadGallons, ' gal'));
+    pushDetailRow(
+      actionTable,
+      'FOB Before Refuel',
+      formatNumberValue(action.ActualFOBAtDepartureBeforeRefuel, ' gal')
+    );
+    pushDetailRow(actionTable, 'Started', formatDateValue(action.StartedTime));
+    pushDetailRow(actionTable, 'Failed', formatDateValue(action.FailedTime));
+    pushDetailRow(actionTable, 'Ended', formatDateValue(action.EndedTime));
+
+    const loads = toArray(action.Loads)
+      .map(getActionLoadDisplay)
+      .filter((load): load is string => typeof load === 'string');
+    const passengers = toArray(action.Passengers)
+      .map(getActionPassengerDisplay)
+      .filter((passenger): passenger is string => typeof passenger === 'string');
+    pushDetailRow(actionTable, 'Loads', loads.length ? loads.join(' / ') : undefined);
+    pushDetailRow(actionTable, 'Passengers', passengers.length ? passengers.join(' / ') : undefined);
+    pushDetailRow(actionTable, 'Flags', getActionFlags(action));
+    console.log(actionTable.toString());
+  });
 };

--- a/src/loggers/logCompanyWorkOrders.ts
+++ b/src/loggers/logCompanyWorkOrders.ts
@@ -191,6 +191,12 @@ const formatDateValue = (value: unknown): string | undefined => {
   return Number.isNaN(date.getTime()) ? dateString : date.toLocaleString('en-GB');
 };
 
+export const getWorkOrderExpectedStart = (workOrder: CompanyWorkOrder): string | undefined => {
+  return getWorkOrderStatus(workOrder) === 'Pending'
+    ? formatDateValue(workOrder.StartDate)
+    : undefined;
+};
+
 const formatNumberValue = (value: unknown, suffix = ''): string | undefined => {
   const number = toNumberValue(value);
   return typeof number === 'undefined' ? undefined : `${number.toLocaleString('en-GB')}${suffix}`;
@@ -313,13 +319,19 @@ export const logCompanyWorkOrders = (
   showWorkOrderId = false
 ) => {
   const workOrderTable = cliTable();
+  const showExpectedStart = workOrders.some((workOrder) => getWorkOrderStatus(workOrder) === 'Pending');
 
   const headerRow = [
     chalk.green('Aircraft'),
     chalk.green('Ident'),
     chalk.green('Status'),
-    chalk.green('Summary'),
   ];
+
+  if (showExpectedStart) {
+    headerRow.push(chalk.green('Expected Start'));
+  }
+
+  headerRow.push(chalk.green('Summary'));
 
   if (showCrewAssigned) {
     headerRow.push(chalk.green('Crew Assigned'));
@@ -332,12 +344,18 @@ export const logCompanyWorkOrders = (
   workOrderTable.push(headerRow);
 
   workOrders.forEach((workOrder) => {
+    const status = getWorkOrderStatus(workOrder);
     const row = [
       getWorkOrderAircraftDisplayName(workOrder) || '-',
       getWorkOrderAircraftIdentifier(workOrder) || '-',
-      getWorkOrderStatus(workOrder) || '-',
-      getWorkOrderSummary(workOrder) || '-',
+      status || '-',
     ];
+
+    if (showExpectedStart) {
+      row.push(getWorkOrderExpectedStart(workOrder) || '-');
+    }
+
+    row.push(getWorkOrderSummary(workOrder) || '-');
 
     if (showCrewAssigned) {
       row.push(getWorkOrderAssignedCrew(workOrder) || '-');

--- a/src/types/CompanyWorkOrder.ts
+++ b/src/types/CompanyWorkOrder.ts
@@ -1,0 +1,36 @@
+export interface WorkOrderNestedAircraftType {
+  DisplayName?: string;
+  TypeName?: string;
+  ICAO?: string;
+  Icao?: string;
+  IcaoCode?: string;
+}
+
+export interface WorkOrderNestedAircraft {
+  Id?: string;
+  Identifier?: string;
+  AircraftType?: WorkOrderNestedAircraftType;
+}
+
+export interface CompanyWorkOrder extends Record<string, unknown> {
+  Id?: string;
+  Status?: string | number;
+  CurrentStatus?: string;
+  WorkOrderStatus?: string;
+  State?: string;
+  Description?: string;
+  Name?: string;
+  Title?: string;
+  Category?: string;
+  AircraftIdentifier?: string;
+  AircraftIcao?: string;
+  AircraftICAO?: string;
+  AircraftId?: string;
+  Aircraft?: WorkOrderNestedAircraft;
+  AircraftType?: WorkOrderNestedAircraftType;
+  AssignedCrew?: unknown;
+  AssignedCrews?: unknown;
+  Crew?: unknown;
+  Crews?: unknown;
+  Employees?: unknown;
+}

--- a/src/utils/fboJobFilters.ts
+++ b/src/utils/fboJobFilters.ts
@@ -1,0 +1,44 @@
+import { Cargo, Charter, Job } from 'onair-api';
+
+export interface FboJobFilters {
+  pendingOnly?: boolean;
+  departureIcao?: string;
+  arrivalIcao?: string;
+}
+
+const getJobLegs = (job: Job): Array<Cargo | Charter> => {
+  return [...job.Cargos, ...job.Charters];
+};
+
+const normalizeIcao = (icao: string | undefined): string | undefined => {
+  const normalizedIcao = icao?.trim().toLocaleUpperCase();
+  return normalizedIcao || undefined;
+};
+
+export const isPendingFboJob = (job: Job): boolean => {
+  return job.State === 0;
+};
+
+export const matchesFboJobFilters = (job: Job, filters: FboJobFilters): boolean => {
+  if (filters.pendingOnly && !isPendingFboJob(job)) {
+    return false;
+  }
+
+  const departureIcao = normalizeIcao(filters.departureIcao);
+  const arrivalIcao = normalizeIcao(filters.arrivalIcao);
+
+  if (!departureIcao && !arrivalIcao) {
+    return true;
+  }
+
+  return getJobLegs(job).some((leg) => {
+    const matchesDeparture = departureIcao
+      ? leg.CurrentAirport?.ICAO?.toLocaleUpperCase() === departureIcao
+      : true;
+    const matchesArrival = arrivalIcao
+      ? leg.DestinationAirport?.ICAO?.toLocaleUpperCase() === arrivalIcao
+      : true;
+
+    return matchesDeparture && matchesArrival;
+  });
+};

--- a/test/fboJobFilters.test.js
+++ b/test/fboJobFilters.test.js
@@ -1,0 +1,41 @@
+const assert = require('assert');
+
+const {
+  isPendingFboJob,
+  matchesFboJobFilters,
+} = require('../bin/utils/fboJobFilters');
+
+const airport = (ICAO) => ({ ICAO });
+const leg = (departure, arrival) => ({
+  CurrentAirport: airport(departure),
+  DestinationAirport: airport(arrival),
+});
+const job = (State, legs) => ({
+  State,
+  Cargos: legs,
+  Charters: [],
+});
+
+const pendingJob = job(0, [
+  leg('KJFK', 'KORD'),
+  leg('KORD', 'KDEN'),
+]);
+const takenJob = job(1, [leg('KJFK', 'KORD')]);
+
+assert.strictEqual(isPendingFboJob(pendingJob), true);
+assert.strictEqual(isPendingFboJob(takenJob), false);
+assert.strictEqual(matchesFboJobFilters(pendingJob, { pendingOnly: true }), true);
+assert.strictEqual(matchesFboJobFilters(takenJob, { pendingOnly: true }), false);
+assert.strictEqual(matchesFboJobFilters(pendingJob, { departureIcao: 'kjfk' }), true);
+assert.strictEqual(matchesFboJobFilters(pendingJob, { arrivalIcao: 'kden' }), true);
+assert.strictEqual(matchesFboJobFilters(pendingJob, {
+  departureIcao: 'KJFK',
+  arrivalIcao: 'KORD',
+}), true);
+assert.strictEqual(matchesFboJobFilters(pendingJob, {
+  departureIcao: 'KJFK',
+  arrivalIcao: 'KDEN',
+}), false, 'departure and arrival must match the same leg');
+assert.strictEqual(matchesFboJobFilters(pendingJob, { departureIcao: 'KLAX' }), false);
+
+console.log('FBO job filter tests passed.');

--- a/test/logCompanyWorkOrders.test.js
+++ b/test/logCompanyWorkOrders.test.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+
+const { getWorkOrderStatus } = require('../bin/loggers/logCompanyWorkOrders');
+
+const aircraft = {
+  AircraftStatus: 3,
+  Identifier: 'NTEST',
+};
+
+const cases = [
+  {
+    name: 'pending work order for an active aircraft',
+    workOrder: { Status: 1, Aircraft: aircraft, Actions: [{ Status: 0 }] },
+    expected: 'Pending',
+  },
+  {
+    name: 'work order with an active action',
+    workOrder: { Status: 1, Aircraft: aircraft, Actions: [{ Status: 1 }] },
+    expected: 'In Progress',
+  },
+  {
+    name: 'pending work order with a finished action lacking status',
+    workOrder: {
+      Status: 1,
+      Aircraft: aircraft,
+      Actions: [{
+        StartedTime: '2026-07-27T10:00:00Z',
+        EndedTime: '2026-07-27T11:00:00Z',
+        FlightId: 'finished-flight',
+      }],
+    },
+    expected: 'Pending',
+  },
+  {
+    name: 'finished work order with historical activity',
+    workOrder: {
+      Status: 2,
+      Aircraft: aircraft,
+      Actions: [{
+        Status: 2,
+        StartedTime: '2026-07-27T10:00:00Z',
+        EndedTime: '2026-07-27T11:00:00Z',
+      }],
+    },
+    expected: 'Finished',
+  },
+  {
+    name: 'waiting work order',
+    workOrder: { Status: 4, Aircraft: aircraft, Actions: [{ Status: 0 }] },
+    expected: 'Waiting',
+  },
+];
+
+cases.forEach(({ name, workOrder, expected }) => {
+  assert.strictEqual(getWorkOrderStatus(workOrder), expected, name);
+});
+
+console.log(`Passed ${cases.length} work-order status regression cases.`);

--- a/test/logCompanyWorkOrders.test.js
+++ b/test/logCompanyWorkOrders.test.js
@@ -1,6 +1,10 @@
 const assert = require('assert');
 
-const { getWorkOrderStatus } = require('../bin/loggers/logCompanyWorkOrders');
+const {
+  getWorkOrderExpectedStart,
+  getWorkOrderStatus,
+  logCompanyWorkOrders,
+} = require('../bin/loggers/logCompanyWorkOrders');
 
 const aircraft = {
   AircraftStatus: 3,
@@ -55,4 +59,33 @@ cases.forEach(({ name, workOrder, expected }) => {
   assert.strictEqual(getWorkOrderStatus(workOrder), expected, name);
 });
 
-console.log(`Passed ${cases.length} work-order status regression cases.`);
+const pendingWithStart = {
+  Status: 1,
+  StartDate: '2026-07-28T13:30:00',
+  Aircraft: aircraft,
+  Actions: [{ Status: 0 }],
+};
+const activeWithStart = {
+  ...pendingWithStart,
+  Actions: [{ Status: 1 }],
+};
+
+assert.match(getWorkOrderExpectedStart(pendingWithStart), /28\/07\/2026.*13:30:00/);
+assert.strictEqual(getWorkOrderExpectedStart(activeWithStart), undefined);
+
+let tableOutput = '';
+const originalConsoleLog = console.log;
+
+try {
+  console.log = (value) => {
+    tableOutput = String(value);
+  };
+  logCompanyWorkOrders([pendingWithStart, activeWithStart]);
+} finally {
+  console.log = originalConsoleLog;
+}
+
+assert.match(tableOutput, /Expected Start/);
+assert.match(tableOutput, /28\/07\/2026.*13:30:00/);
+
+console.log(`Passed ${cases.length} status cases and expected-start display cases.`);

--- a/test/logCompanyWorkOrders.test.js
+++ b/test/logCompanyWorkOrders.test.js
@@ -4,6 +4,7 @@ const {
   getWorkOrderExpectedStart,
   getWorkOrderStatus,
   logCompanyWorkOrders,
+  matchesWorkOrderStatus,
 } = require('../bin/loggers/logCompanyWorkOrders');
 
 const aircraft = {
@@ -59,6 +60,11 @@ cases.forEach(({ name, workOrder, expected }) => {
   assert.strictEqual(getWorkOrderStatus(workOrder), expected, name);
 });
 
+assert.strictEqual(matchesWorkOrderStatus(cases[0].workOrder, 'pending'), true);
+assert.strictEqual(matchesWorkOrderStatus(cases[0].workOrder, 'in-progress'), false);
+assert.strictEqual(matchesWorkOrderStatus(cases[1].workOrder, 'in-progress'), true);
+assert.strictEqual(matchesWorkOrderStatus(cases[1].workOrder, 'In Progress'), true);
+
 const pendingWithStart = {
   Status: 1,
   StartDate: '2026-07-28T13:30:00',
@@ -88,4 +94,4 @@ try {
 assert.match(tableOutput, /Expected Start/);
 assert.match(tableOutput, /28\/07\/2026.*13:30:00/);
 
-console.log(`Passed ${cases.length} status cases and expected-start display cases.`);
+console.log(`Passed ${cases.length} status cases, status-filter cases, and expected-start display cases.`);


### PR DESCRIPTION
## What changed

- add `--work-order-detail=WORK_ORDER_ID` to the company work-orders command
- display work-order metadata, assigned crew, and action details
- document the new command option and example

## Why

The existing work-order list can expose IDs, but it did not provide a focused view of the underlying work order and its actions.

## Impact

Users can now inspect one work order by ID without expanding the normal list output. Existing work-order listing and filtering behavior is unchanged.

## Validation

- `npm run build`
- `npx eslint src/commands/company.ts src/loggers/logCompanyWorkOrders.ts`
- full `npm run lint` was also attempted; it reports two pre-existing `no-extra-boolean-cast` errors in `src/loggers/logCompanyTradingGoods.ts`
